### PR TITLE
Add comprehensive part naming system with support for all major fastener categories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ certificates/
 
 # User's global config (shouldn't be in project but just in case)
 ~/.config/mmcli/
+
+# Claude Code configuration
+.claude/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,6 +713,7 @@ dependencies = [
  "clap",
  "dirs",
  "native-tls",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",
@@ -899,6 +909,35 @@ dependencies = [
  "libredox",
  "thiserror",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reqwest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ dirs = "5.0"
 toml = "0.8"
 native-tls = "0.2"
 urlencoding = "2.1"
+regex = "1.0"
 
 [[bin]]
 name = "mmc"

--- a/README.md
+++ b/README.md
@@ -264,6 +264,47 @@ McMaster-Carr CLI supports 19 different washer types with specific naming patter
 
 *Note: Supports various standoff configurations including male-female, female-only, and specialized types for electronics and mechanical assemblies.*
 
+#### Bearings
+
+McMaster-Carr CLI provides comprehensive bearing support with specialized naming for different bearing types:
+
+| Type | Template | Example Input | Generated Name |
+|------|----------|---------------|----------------|
+| Flanged Sleeve Bearing | `FSB-[Material]-[Shaft Diameter]-[OD]-[Length]` | MDS-Filled Nylon, 1/4" shaft, 3/8" OD, 1/4" long | `FSB-MDSNYL-0.25-0.375-0.25` |
+| Plain Sleeve Bearing | `SB-[Material]-[Shaft Diameter]-[OD]-[Length]` | Bronze SAE 841, 3/8" shaft, 1/2" OD, 1/2" long | `SB-BR841-0.375-0.5-0.5` |
+| Flanged Bearing (generic) | `FB-[Material]-[Shaft Diameter]-[OD]-[Length]` | Steel flanged bearing, 1/2" shaft, 5/8" OD | `FB-STL-0.5-0.625-0.5` |
+| Ball Bearing | `BB-[Material]-[Bore]-[OD]` | Stainless steel ball bearing, 6mm bore, 19mm OD | `BB-SS-6-19` |
+| Linear Bearing | `LB-[Material]-[Shaft Diameter]-[Length]` | Steel linear bearing for 3/8" shaft, 2" long | `LB-STL-0.375-2` |
+| Needle Bearing | `NB-[Material]-[Bore]-[OD]-[Length]` | Steel needle bearing, 1/4" bore, 3/8" OD | `NB-STL-0.25-0.375-0.5` |
+| Roller Bearing | `RB-[Material]-[Bore]-[OD]-[Length]` | Bronze roller bearing, 20mm bore, 35mm OD | `RB-BR-20-35-12` |
+| Generic Bearing | `BRG-[Material]-[Type]` | PTFE bearing assembly | `BRG-PTFE-ASSEMBLY` |
+
+**Special Features:**
+- **Automatic Material Detection**: Combines filler materials (e.g., MDS-Filled Nylon)
+- **Dimension Conversion**: Fractions automatically converted to decimals (1/4" → 0.25)
+- **Metric Support**: Handles both imperial and metric dimensions
+- **Comprehensive Coverage**: Supports plain, flanged, ball, linear, needle, and roller bearings
+
+**Bearing Material Abbreviations:**
+
+| Full Name | Abbreviation | Applications |
+|-----------|--------------|-------------|
+| MDS-Filled Nylon Plastic | `MDSNYL` | Dry-running, self-lubricating applications |
+| Nylon Plastic | `NYL` | Light-duty, corrosion-resistant |
+| Bronze SAE 841 | `BR841` | Oil-impregnated, general purpose |
+| Bronze SAE 863 | `BR863` | High-load applications |
+| Cast Bronze | `CB` | Heavy-duty applications |
+| Oil-Filled Bronze | `OFB` | Self-lubricating bronze |
+| PTFE | `PTFE` | Chemical resistance, low friction |
+| Rulon | `RUL` | Dry-running plastic bearing |
+| Graphite | `GRAPH` | High-temperature applications |
+| Steel-Backed PTFE | `SBPTFE` | High-load PTFE applications |
+| Bronze (generic) | `BR` | General bronze bearings |
+| Steel | `STL` | High-strength applications |
+| Stainless Steel | `SS` | Corrosion-resistant steel |
+
+*Note: The system automatically detects bearing type from product specifications and applies the appropriate template. Filler materials are automatically combined with base materials for accurate naming.*
+
 #### Material Abbreviations
 
 | Full Name | Abbreviation | Notes |

--- a/README.md
+++ b/README.md
@@ -185,10 +185,10 @@ McMaster-Carr CLI can generate human-readable, abbreviated technical names for p
 ```bash
 # Generate abbreviated technical name for any part
 mmc name 98164A133
-# Output: BHS-SS316-8-32-0.25-HEX
+# Output: BHS-SS316-8x32-0.25-HEX
 
-mmc name 91831A005  
-# Output: LOCKNUT-SS188-4-40
+mmc name 90480A005  
+# Output: HEXNUT-Steel-4x40-ZP
 ```
 
 ### Supported Categories
@@ -197,29 +197,29 @@ mmc name 91831A005
 
 | Type | Template | Example Input | Generated Name |
 |------|----------|---------------|----------------|
-| Button Head Screw | `BHS-[Material]-[Thread]-[Length]-[Drive]` | 316 SS Button Head Hex, 8-32 x 1/4" | `BHS-SS316-8-32-0.25-HEX` |
-| Socket Head Screw | `SHS-[Material]-[Thread]-[Length]-[Drive]` | Steel Socket Head Hex, 1/4-20 x 1" | `SHS-Steel-1/4-20-1-HEX` |
-| Flat Head Screw | `FHS-[Material]-[Thread]-[Length]-[Drive]` | 18-8 SS Flat Head Phillips, M6 x 20mm | `FHS-SS188-M6-20-PH` |
-| Pan Head Screw | `PHS-[Material]-[Thread]-[Length]-[Drive]` | Brass Pan Head Phillips, 6-32 x 0.5" | `PHS-Brass-6-32-0.5-PH` |
-| Hex Head Screw | `HHS-[Material]-[Thread]-[Length]` | SS Hex Head Screw, 1/4-20 x 1" | `HHS-SS-1/4-20-1` |
-| Rounded Head Screw | `RHS-[Material]-[Thread]-[Length]-[Drive]` | Steel Rounded Head Phillips, 8-32 x 0.5" | `RHS-Steel-8-32-0.5-PH` |
-| Thumb Screw | `THUMB-[Material]-[Thread]-[Length]` | Brass Thumb Screw, M6 x 20mm | `THUMB-Brass-M6-20` |
-| Eye Screw | `EYE-[Material]-[Thread]-[Length]` | Steel Eye Screw, 1/4-20 x 2" | `EYE-Steel-1/4-20-2` |
-| Hook Screw | `HOOK-[Material]-[Thread]-[Length]` | SS Hook Screw, 8-32 x 1" | `HOOK-SS-8-32-1` |
+| Button Head Screw | `BHS-[Material]-[Thread]-[Length]-[Drive]-[Finish]` | 316 SS Button Head Hex, 8x32 x 0.25" | `BHS-SS316-8x32-0.25-HEX` |
+| Socket Head Screw | `SHS-[Material]-[Thread]-[Length]-[Drive]-[Finish]` | Steel Socket Head Hex, 1/4x20 x 1" | `SHS-Steel-1/4x20-1-HEX` |
+| Flat Head Screw | `FHS-[Material]-[Thread]-[Length]-[Drive]-[Finish]` | 18-8 SS Flat Head Phillips, M6x1.0 x 20mm | `FHS-SS188-M6x1.0-20-PH` |
+| Pan Head Screw | `PHS-[Material]-[Thread]-[Length]-[Drive]-[Finish]` | Brass Pan Head Phillips, 6x32 x 0.5" | `PHS-Brass-6x32-0.5-PH` |
+| Hex Head Screw | `HHS-[Material]-[Thread]-[Length]-[Drive]-[Finish]` | SS Hex Head Screw, 1/4x20 x 1" | `HHS-SS-1/4x20-1-EHEX` |
+| Rounded Head Screw | `RHS-[Material]-[Thread]-[Length]-[Drive]-[Finish]` | Steel Rounded Head Phillips, 8x32 x 0.5" | `RHS-Steel-8x32-0.5-PH` |
+| Thumb Screw | `THUMB-[Material]-[Thread]-[Length]-[Finish]` | Brass Thumb Screw, M6x1.0 x 20mm | `THUMB-Brass-M6x1.0-20` |
+| Eye Screw | `EYE-[Material]-[Thread]-[Length]-[Finish]` | Steel Eye Screw, 1/4x20 x 2" | `EYE-Steel-1/4x20-2` |
+| Hook Screw | `HOOK-[Material]-[Thread]-[Length]-[Finish]` | SS Hook Screw, 8x32 x 1" | `HOOK-SS-8x32-1` |
 
 *Note: Supports 20+ head types including T-Handle, Pentagon, Oval, Square, Knob, Ring, and specialty types. See code for complete list.*
 
-| Generic Screw | `SCREW-[Material]-[Thread]-[Length]` | Brass Machine Screw, 6-32 x 0.5" | `SCREW-Brass-6-32-0.5` |
+| Generic Screw | `SCREW-[Material]-[Thread]-[Length]` | Brass Machine Screw, 6x32 x 0.5" | `SCREW-Brass-6x32-0.5` |
 
 #### Nuts
 
 | Type | Template | Example Input | Generated Name |
 |------|----------|---------------|----------------|
-| Locknut | `LOCKNUT-[Material]-[Thread]` | 18-8 SS Nylon-Insert Locknut, 4-40 | `LOCKNUT-SS188-4-40` |
-| Hex Nut | `HEXNUT-[Material]-[Thread]-[Height]` | 316 SS Hex Nut, 1/4-20, 7/32" H | `HEXNUT-SS316-1/4-20-7/32` |
-| Wing Nut | `WINGNUT-[Material]-[Thread]` | Brass Wing Nut, 8-32 | `WINGNUT-Brass-8-32` |
-| Cap Nut | `CAPNUT-[Material]-[Thread]-[Height]` | SS Cap Nut, M8, 12mm H | `CAPNUT-SS-M8-12` |
-| Generic Nut | `NUT-[Material]-[Thread]` | Steel Nut, 5/16-18 | `NUT-Steel-5/16-18` |
+| Locknut | `LOCKNUT-[Material]-[Thread]-[Finish]` | 18-8 SS Nylon-Insert Locknut, 4x40 | `LOCKNUT-SS188-4x40` |
+| Hex Nut | `HEXNUT-[Material]-[Thread]-[Finish]` | 316 SS Hex Nut, 1/4x20, Zinc-Plated | `HEXNUT-SS316-1/4x20-ZP` |
+| Wing Nut | `WINGNUT-[Material]-[Thread]-[Finish]` | Brass Wing Nut, 8x32 | `WINGNUT-Brass-8x32` |
+| Cap Nut | `CAPNUT-[Material]-[Thread]-[Finish]` | SS Cap Nut, M8x1.25 | `CAPNUT-SS-M8x1.25` |
+| Generic Nut | `NUT-[Material]-[Thread]-[Finish]` | Steel Nut, 5/16x18 | `NUT-Steel-5/16x18` |
 
 #### Washers
 
@@ -227,27 +227,28 @@ McMaster-Carr CLI supports 19 different washer types with specific naming patter
 
 | Type | Template | Example Input | Generated Name |
 |------|----------|---------------|----------------|
-| Cup Washer | `CUP-[Material]-[Screw Size]` | 316 SS Cup Washer for 1/4" Screws | `CUP-SS316-1/4` |
-| Curved Washer | `CURVED-[Material]-[Screw Size]` | Steel Curved Washer for 8-32 | `CURVED-Steel-8-32` |
-| Dished Washer | `DISHED-[Material]-[Screw Size]` | Brass Dished Washer for M6 | `DISHED-Brass-M6` |
-| Domed Washer | `DOMED-[Material]-[Screw Size]` | 18-8 SS Domed Washer for 1/4-20 | `DOMED-SS188-1/4-20` |
-| Double Clipped Washer | `DBLCLIP-[Material]-[Screw Size]` | Steel Double Clipped for #10 | `DBLCLIP-Steel-10` |
-| Flat Washer | `FLAT-[Material]-[Screw Size]` | 316 SS Flat Washer for 1/4" | `FLAT-SS316-1/4` |
-| Hillside Washer | `HILLSIDE-[Material]-[Screw Size]` | Steel Hillside Washer for M8 | `HILLSIDE-Steel-M8` |
-| Notched Washer | `NOTCHED-[Material]-[Screw Size]` | Aluminum Notched Washer for 6-32 | `NOTCHED-Al-6-32` |
-| Perforated Washer | `PERF-[Material]-[Screw Size]` | SS Perforated Washer for 1/2" | `PERF-SS-1/2` |
-| Pronged Washer | `PRONGED-[Material]-[Screw Size]` | Steel Pronged Washer for M5 | `PRONGED-Steel-M5` |
-| Rectangular Washer | `RECT-[Material]-[Screw Size]` | Nylon Rectangular for 10-24 | `RECT-Nylon-10-24` |
-| Sleeve Washer | `SLEEVE-[Material]-[Screw Size]` | Brass Sleeve Washer for 1/4" | `SLEEVE-Brass-1/4` |
-| Slotted Washer | `SLOTTED-[Material]-[Screw Size]` | SS Slotted Washer for M6 | `SLOTTED-SS-M6` |
-| Spherical Washer | `SPHERE-[Material]-[Screw Size]` | Steel Spherical for 5/16" | `SPHERE-Steel-5/16` |
-| Split Washer (Lock) | `SPLIT-[Material]-[Screw Size]` | 18-8 SS Split Lock for 8-32 | `SPLIT-SS188-8-32` |
-| Square Washer | `SQUARE-[Material]-[Screw Size]` | Steel Square Washer for M8 | `SQUARE-Steel-M8` |
-| Tab Washer | `TAB-[Material]-[Screw Size]` | SS Tab Washer for 1/4-20 | `TAB-SS-1/4-20` |
-| Tapered Washer | `TAPERED-[Material]-[Screw Size]` | Steel Tapered for 3/8" | `TAPERED-Steel-3/8` |
-| Tooth Washer | `TOOTH-[Material]-[Screw Size]` | SS Tooth Lock Washer for M10 | `TOOTH-SS-M10` |
-| Wave Washer | `WAVE-[Material]-[Screw Size]` | Spring Steel Wave for 1/4" | `WAVE-Steel-1/4` |
-| Wedge Washer | `WEDGE-[Material]-[Screw Size]` | Steel Wedge Washer for M12 | `WEDGE-Steel-M12` |
+| Cup Washer | `CW-[Material]-[Screw Size]-[Finish]` | 316 SS Cup Washer for 1/4" Screws | `CW-SS316-1/4` |
+| Curved Washer | `CRVW-[Material]-[Screw Size]-[Finish]` | Steel Curved Washer for 8x32 | `CRVW-Steel-8x32` |
+| Dished Washer | `DW-[Material]-[Screw Size]-[Finish]` | Brass Dished Washer for M6 | `DW-Brass-M6` |
+| Domed Washer | `DMW-[Material]-[Screw Size]-[Finish]` | 18-8 SS Domed Washer for 1/4x20 | `DMW-SS188-1/4x20` |
+| Double Clipped Washer | `DCW-[Material]-[Screw Size]-[Finish]` | Steel Double Clipped for #10 | `DCW-Steel-10` |
+| Clipped Washer | `CLW-[Material]-[Screw Size]-[Finish]` | Steel Clipped Washer for 5/16" | `CLW-Steel-5/16` |
+| Flat Washer | `FW-[Material]-[Screw Size]-[Finish]` | 316 SS Flat Washer for 1/4" | `FW-SS316-1/4` |
+| Hillside Washer | `HW-[Material]-[Screw Size]-[Finish]` | Steel Hillside Washer for M8 | `HW-Steel-M8` |
+| Notched Washer | `NW-[Material]-[Screw Size]-[Finish]` | Aluminum Notched Washer for 6x32 | `NW-Al-6x32` |
+| Perforated Washer | `PW-[Material]-[Screw Size]-[Finish]` | SS Perforated Washer for 1/2" | `PW-SS-1/2` |
+| Pronged Washer | `PRW-[Material]-[Screw Size]-[Finish]` | Steel Pronged Washer for M5 | `PRW-Steel-M5` |
+| Rectangular Washer | `RW-[Material]-[Screw Size]-[Finish]` | Nylon Rectangular for 10x24 | `RW-Nylon-10x24` |
+| Sleeve Washer | `SW-[Material]-[Screw Size]-[Finish]` | Brass Sleeve Washer for 1/4" | `SW-Brass-1/4` |
+| Slotted Washer | `SLW-[Material]-[Screw Size]-[Finish]` | SS Slotted Washer for M6 | `SLW-SS-M6` |
+| Spherical Washer | `SPW-[Material]-[Screw Size]-[Finish]` | Steel Spherical for 5/16" | `SPW-Steel-5/16` |
+| Split Washer (Lock) | `SPLW-[Material]-[Screw Size]-[Finish]` | 18-8 SS Split Lock for 8x32 | `SPLW-SS188-8x32` |
+| Square Washer | `SQW-[Material]-[Screw Size]-[Finish]` | Steel Square Washer for M8 | `SQW-Steel-M8` |
+| Tab Washer | `TW-[Material]-[Screw Size]-[Finish]` | SS Tab Washer for 1/4x20 | `TW-SS-1/4x20` |
+| Tapered Washer | `TPW-[Material]-[Screw Size]-[Finish]` | Steel Tapered for 3/8" | `TPW-Steel-3/8` |
+| Tooth Washer | `TOW-[Material]-[Screw Size]-[Finish]` | SS Tooth Lock Washer for M10 | `TOW-SS-M10` |
+| Wave Washer | `WW-[Material]-[Screw Size]-[Finish]` | Spring Steel Wave for 1/4" | `WW-Steel-1/4` |
+| Wedge Washer | `WDW-[Material]-[Screw Size]-[Finish]` | Steel Wedge Washer for M12 | `WDW-Steel-M12` |
 
 *Note: The system automatically detects washer type from the family description and applies the appropriate template. If no specific type is detected, it defaults to flat washer naming.*
 
@@ -265,6 +266,19 @@ McMaster-Carr CLI supports 19 different washer types with specific naming patter
 | Nylon | `Nylon` | Nylon plastic |
 | Plastic | `Plastic` | Various plastic materials |
 | Rubber | `Rubber` | Rubber materials |
+
+#### Finish Abbreviations
+
+| Full Name | Abbreviation | Notes |
+|-----------|--------------|-------|
+| Zinc Plated | `ZP` | Standard zinc coating |
+| Zinc Yellow-Chromate Plated | `ZYC` | Zinc with yellow chromate |
+| Black Oxide | `BO` | Black oxide coating |
+| Cadmium Plated | `CD` | Cadmium coating |
+| Nickel Plated | `NI` | Nickel coating |
+| Chrome Plated | `CR` | Chrome coating |
+| Galvanized | `GAL` | Hot-dip galvanized |
+| Passivated | `PASS` | Omitted in names (not meaningful info) |
 
 #### Drive Style Abbreviations
 
@@ -285,10 +299,11 @@ McMaster-Carr CLI supports 19 different washer types with specific naming patter
 
 ### Dimension Formatting
 
-- **Fractions**: Automatically converted to decimals (`1/4"` → `0.25`)
-- **Inches**: Quote marks removed for cleaner names (`0.25"` → `0.25`)
-- **Metric**: Preserved as-is (`M6`, `20mm`)
-- **Thread Sizes**: Preserved as-is (`8-32`, `1/4-20`, `M6x1.0`)
+- **Imperial Lengths**: Fractions automatically converted to decimals (`1/4"` → `0.25`)
+- **Metric Lengths**: mm suffix removed (`20mm` → `20`)
+- **Thread Sizes**: Use "x" separator for size/pitch (`8-32` → `8x32`, `M3 x 0.50mm` → `M3x0.50`)
+- **Washer Sizes**: Preserve fractions for screw compatibility (`1/4"` → `1/4`)
+- **Quote Marks**: Removed for cleaner names (`"` removed)
 
 ### Fallback Naming
 
@@ -302,14 +317,14 @@ For unsupported categories, the system generates fallback names using:
 #### BOM Usage
 ```csv
 Part Number,Description,Generated Name,Quantity
-98164A133,316 SS Button Head Hex Drive Screw,BHS-SS316-8-32-0.25-HEX,10
-91831A005,18-8 SS Nylon-Insert Locknut,LOCKNUT-SS188-4-40,10
+98164A133,316 SS Button Head Hex Drive Screw,BHS-SS316-8x32-0.25-HEX,10
+90480A005,Low-Strength Steel Hex Nut,HEXNUT-Steel-4x40-ZP,10
 ```
 
 #### Scripting
 ```bash
 # Generate names for a list of parts
-for part in 98164A133 91831A005; do
+for part in 98164A133 90480A005; do
   echo "$part: $(mmc name $part)"
 done
 

--- a/README.md
+++ b/README.md
@@ -198,9 +198,17 @@ mmc name 91831A005
 | Type | Template | Example Input | Generated Name |
 |------|----------|---------------|----------------|
 | Button Head Screw | `BHS-[Material]-[Thread]-[Length]-[Drive]` | 316 SS Button Head Hex, 8-32 x 1/4" | `BHS-SS316-8-32-0.25-HEX` |
-| Flat Head Screw | `FHS-[Material]-[Thread]-[Length]-[Drive]` | 18-8 SS Flat Head Phillips, M6 x 20mm | `FHS-SS188-M6-20-PH` |
 | Socket Head Screw | `SHS-[Material]-[Thread]-[Length]-[Drive]` | Steel Socket Head Hex, 1/4-20 x 1" | `SHS-Steel-1/4-20-1-HEX` |
+| Flat Head Screw | `FHS-[Material]-[Thread]-[Length]-[Drive]` | 18-8 SS Flat Head Phillips, M6 x 20mm | `FHS-SS188-M6-20-PH` |
 | Pan Head Screw | `PHS-[Material]-[Thread]-[Length]-[Drive]` | Brass Pan Head Phillips, 6-32 x 0.5" | `PHS-Brass-6-32-0.5-PH` |
+| Hex Head Screw | `HHS-[Material]-[Thread]-[Length]` | SS Hex Head Screw, 1/4-20 x 1" | `HHS-SS-1/4-20-1` |
+| Rounded Head Screw | `RHS-[Material]-[Thread]-[Length]-[Drive]` | Steel Rounded Head Phillips, 8-32 x 0.5" | `RHS-Steel-8-32-0.5-PH` |
+| Thumb Screw | `THUMB-[Material]-[Thread]-[Length]` | Brass Thumb Screw, M6 x 20mm | `THUMB-Brass-M6-20` |
+| Eye Screw | `EYE-[Material]-[Thread]-[Length]` | Steel Eye Screw, 1/4-20 x 2" | `EYE-Steel-1/4-20-2` |
+| Hook Screw | `HOOK-[Material]-[Thread]-[Length]` | SS Hook Screw, 8-32 x 1" | `HOOK-SS-8-32-1` |
+
+*Note: Supports 20+ head types including T-Handle, Pentagon, Oval, Square, Knob, Ring, and specialty types. See code for complete list.*
+
 | Generic Screw | `SCREW-[Material]-[Thread]-[Length]` | Brass Machine Screw, 6-32 x 0.5" | `SCREW-Brass-6-32-0.5` |
 
 #### Nuts

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ McMaster-Carr CLI can generate human-readable, abbreviated technical names for p
 ```bash
 # Generate abbreviated technical name for any part
 mmc name 98164A133
-# Output: BHCS-SS316-8-32-0.25-HEX
+# Output: BHS-SS316-8-32-0.25-HEX
 
 mmc name 91831A005  
 # Output: LOCKNUT-SS188-4-40
@@ -197,9 +197,10 @@ mmc name 91831A005
 
 | Type | Template | Example Input | Generated Name |
 |------|----------|---------------|----------------|
-| Button Head Cap Screw | `BHCS-[Material]-[Thread]-[Length]-[Drive]` | 316 SS Button Head Hex, 8-32 x 1/4" | `BHCS-SS316-8-32-0.25-HEX` |
-| Flat Head Cap Screw | `FHCS-[Material]-[Thread]-[Length]-[Drive]` | 18-8 SS Flat Head Phillips, M6 x 20mm | `FHCS-SS188-M6-20-PH` |
-| Socket Head Cap Screw | `SHCS-[Material]-[Thread]-[Length]-[Drive]` | Steel Socket Head Hex, 1/4-20 x 1" | `SHCS-Steel-1/4-20-1-HEX` |
+| Button Head Screw | `BHS-[Material]-[Thread]-[Length]-[Drive]` | 316 SS Button Head Hex, 8-32 x 1/4" | `BHS-SS316-8-32-0.25-HEX` |
+| Flat Head Screw | `FHS-[Material]-[Thread]-[Length]-[Drive]` | 18-8 SS Flat Head Phillips, M6 x 20mm | `FHS-SS188-M6-20-PH` |
+| Socket Head Screw | `SHS-[Material]-[Thread]-[Length]-[Drive]` | Steel Socket Head Hex, 1/4-20 x 1" | `SHS-Steel-1/4-20-1-HEX` |
+| Pan Head Screw | `PHS-[Material]-[Thread]-[Length]-[Drive]` | Brass Pan Head Phillips, 6-32 x 0.5" | `PHS-Brass-6-32-0.5-PH` |
 | Generic Screw | `SCREW-[Material]-[Thread]-[Length]` | Brass Machine Screw, 6-32 x 0.5" | `SCREW-Brass-6-32-0.5` |
 
 #### Nuts
@@ -257,7 +258,7 @@ For unsupported categories, the system generates fallback names using:
 #### BOM Usage
 ```csv
 Part Number,Description,Generated Name,Quantity
-98164A133,316 SS Button Head Hex Drive Screw,BHCS-SS316-8-32-0.25-HEX,10
+98164A133,316 SS Button Head Hex Drive Screw,BHS-SS316-8-32-0.25-HEX,10
 91831A005,18-8 SS Nylon-Insert Locknut,LOCKNUT-SS188-4-40,10
 ```
 

--- a/README.md
+++ b/README.md
@@ -232,12 +232,20 @@ mmc name 91831A005
 
 #### Drive Style Abbreviations
 
-| Full Name | Abbreviation |
-|-----------|--------------|
-| Hex | `HEX` |
-| Phillips | `PH` |
-| Torx | `TX` |
-| Slotted | `SL` |
+| Full Name | Abbreviation | Notes |
+|-----------|--------------|-------|
+| External Hex | `EHEX` | External hex head |
+| Hex | `HEX` | Internal hex (Allen/socket) |
+| Phillips | `PH` | Phillips head |
+| Torx | `TX` | Standard Torx |
+| Torx Plus | `TXP` | Torx Plus drive |
+| Slotted | `SL` | Flat/slotted drive |
+| Square | `SQUARE` | Robertson/square drive |
+| Tamper-Resistant Hex | `TRHEX` | Security hex |
+| Tamper-Resistant Torx | `TRTX` | Security Torx |
+| Pozidriv® | `PZ` | Pozidriv drive |
+
+*Note: McMaster-Carr supports 40+ drive styles. See code for complete list.*
 
 ### Dimension Formatting
 

--- a/README.md
+++ b/README.md
@@ -223,9 +223,33 @@ mmc name 91831A005
 
 #### Washers
 
+McMaster-Carr CLI supports 19 different washer types with specific naming patterns:
+
 | Type | Template | Example Input | Generated Name |
 |------|----------|---------------|----------------|
-| Washer | `WASHER-[Material]-[ID]-[OD]` | 316 SS Flat Washer, 1/4" ID, 5/8" OD | `WASHER-SS316-0.25-0.625` |
+| Cup Washer | `CUP-[Material]-[Screw Size]` | 316 SS Cup Washer for 1/4" Screws | `CUP-SS316-1/4` |
+| Curved Washer | `CURVED-[Material]-[Screw Size]` | Steel Curved Washer for 8-32 | `CURVED-Steel-8-32` |
+| Dished Washer | `DISHED-[Material]-[Screw Size]` | Brass Dished Washer for M6 | `DISHED-Brass-M6` |
+| Domed Washer | `DOMED-[Material]-[Screw Size]` | 18-8 SS Domed Washer for 1/4-20 | `DOMED-SS188-1/4-20` |
+| Double Clipped Washer | `DBLCLIP-[Material]-[Screw Size]` | Steel Double Clipped for #10 | `DBLCLIP-Steel-10` |
+| Flat Washer | `FLAT-[Material]-[Screw Size]` | 316 SS Flat Washer for 1/4" | `FLAT-SS316-1/4` |
+| Hillside Washer | `HILLSIDE-[Material]-[Screw Size]` | Steel Hillside Washer for M8 | `HILLSIDE-Steel-M8` |
+| Notched Washer | `NOTCHED-[Material]-[Screw Size]` | Aluminum Notched Washer for 6-32 | `NOTCHED-Al-6-32` |
+| Perforated Washer | `PERF-[Material]-[Screw Size]` | SS Perforated Washer for 1/2" | `PERF-SS-1/2` |
+| Pronged Washer | `PRONGED-[Material]-[Screw Size]` | Steel Pronged Washer for M5 | `PRONGED-Steel-M5` |
+| Rectangular Washer | `RECT-[Material]-[Screw Size]` | Nylon Rectangular for 10-24 | `RECT-Nylon-10-24` |
+| Sleeve Washer | `SLEEVE-[Material]-[Screw Size]` | Brass Sleeve Washer for 1/4" | `SLEEVE-Brass-1/4` |
+| Slotted Washer | `SLOTTED-[Material]-[Screw Size]` | SS Slotted Washer for M6 | `SLOTTED-SS-M6` |
+| Spherical Washer | `SPHERE-[Material]-[Screw Size]` | Steel Spherical for 5/16" | `SPHERE-Steel-5/16` |
+| Split Washer (Lock) | `SPLIT-[Material]-[Screw Size]` | 18-8 SS Split Lock for 8-32 | `SPLIT-SS188-8-32` |
+| Square Washer | `SQUARE-[Material]-[Screw Size]` | Steel Square Washer for M8 | `SQUARE-Steel-M8` |
+| Tab Washer | `TAB-[Material]-[Screw Size]` | SS Tab Washer for 1/4-20 | `TAB-SS-1/4-20` |
+| Tapered Washer | `TAPERED-[Material]-[Screw Size]` | Steel Tapered for 3/8" | `TAPERED-Steel-3/8` |
+| Tooth Washer | `TOOTH-[Material]-[Screw Size]` | SS Tooth Lock Washer for M10 | `TOOTH-SS-M10` |
+| Wave Washer | `WAVE-[Material]-[Screw Size]` | Spring Steel Wave for 1/4" | `WAVE-Steel-1/4` |
+| Wedge Washer | `WEDGE-[Material]-[Screw Size]` | Steel Wedge Washer for M12 | `WEDGE-Steel-M12` |
+
+*Note: The system automatically detects washer type from the family description and applies the appropriate template. If no specific type is detected, it defaults to flat washer naming.*
 
 #### Material Abbreviations
 
@@ -237,6 +261,10 @@ mmc name 91831A005
 | Steel | `Steel` | Carbon/alloy steel |
 | Brass | `Brass` | Brass alloy |
 | Aluminum | `Al` | Aluminum alloy |
+| Copper | `Cu` | Copper alloy |
+| Nylon | `Nylon` | Nylon plastic |
+| Plastic | `Plastic` | Various plastic materials |
+| Rubber | `Rubber` | Rubber materials |
 
 #### Drive Style Abbreviations
 

--- a/README.md
+++ b/README.md
@@ -151,17 +151,126 @@ mmc remove 90128a211
 ### Product Information
 
 ```bash
-# Get detailed product information
-mmc product 90128a211
+# Get detailed product information (human-friendly)
+mmc info 98164A133
 
-# Get product pricing
-mmc price 90128a211
+# Get product information in JSON format (scriptable)
+mmc info 98164A133 --output json
+
+# Get specific fields only
+mmc info 98164A133 --fields part-number,material,thread-size
+
+# Get product pricing (human-friendly)
+mmc price 98164A133
+
+# Get pricing in JSON format
+mmc price 98164A133 --output json
+
+# Generate human-readable part name
+mmc name 98164A133
 
 # List recent changes (requires start date)
 mmc changes -s "01/01/2024"
 
 # List changes from a specific date with time
 mmc changes -s "08/20/2025 10:30"
+```
+
+## Name Generation
+
+McMaster-Carr CLI can generate human-readable, abbreviated technical names for parts. This makes parts easier to remember, communicate, and use in BOMs or CAD systems.
+
+### Usage
+
+```bash
+# Generate abbreviated technical name for any part
+mmc name 98164A133
+# Output: BHCS-SS316-8-32-0.25-HEX
+
+mmc name 91831A005  
+# Output: LOCKNUT-SS188-4-40
+```
+
+### Supported Categories
+
+#### Screws & Bolts
+
+| Type | Template | Example Input | Generated Name |
+|------|----------|---------------|----------------|
+| Button Head Cap Screw | `BHCS-[Material]-[Thread]-[Length]-[Drive]` | 316 SS Button Head Hex, 8-32 x 1/4" | `BHCS-SS316-8-32-0.25-HEX` |
+| Flat Head Cap Screw | `FHCS-[Material]-[Thread]-[Length]-[Drive]` | 18-8 SS Flat Head Phillips, M6 x 20mm | `FHCS-SS188-M6-20-PH` |
+| Socket Head Cap Screw | `SHCS-[Material]-[Thread]-[Length]-[Drive]` | Steel Socket Head Hex, 1/4-20 x 1" | `SHCS-Steel-1/4-20-1-HEX` |
+| Generic Screw | `SCREW-[Material]-[Thread]-[Length]` | Brass Machine Screw, 6-32 x 0.5" | `SCREW-Brass-6-32-0.5` |
+
+#### Nuts
+
+| Type | Template | Example Input | Generated Name |
+|------|----------|---------------|----------------|
+| Locknut | `LOCKNUT-[Material]-[Thread]` | 18-8 SS Nylon-Insert Locknut, 4-40 | `LOCKNUT-SS188-4-40` |
+| Hex Nut | `HEXNUT-[Material]-[Thread]-[Height]` | 316 SS Hex Nut, 1/4-20, 7/32" H | `HEXNUT-SS316-1/4-20-7/32` |
+| Wing Nut | `WINGNUT-[Material]-[Thread]` | Brass Wing Nut, 8-32 | `WINGNUT-Brass-8-32` |
+| Cap Nut | `CAPNUT-[Material]-[Thread]-[Height]` | SS Cap Nut, M8, 12mm H | `CAPNUT-SS-M8-12` |
+| Generic Nut | `NUT-[Material]-[Thread]` | Steel Nut, 5/16-18 | `NUT-Steel-5/16-18` |
+
+#### Washers
+
+| Type | Template | Example Input | Generated Name |
+|------|----------|---------------|----------------|
+| Washer | `WASHER-[Material]-[ID]-[OD]` | 316 SS Flat Washer, 1/4" ID, 5/8" OD | `WASHER-SS316-0.25-0.625` |
+
+#### Material Abbreviations
+
+| Full Name | Abbreviation | Notes |
+|-----------|--------------|-------|
+| 316 Stainless Steel | `SS316` | Marine grade, high corrosion resistance |
+| 18-8 Stainless Steel | `SS188` | Standard grade, good corrosion resistance |
+| Stainless Steel (generic) | `SS` | When specific grade not specified |
+| Steel | `Steel` | Carbon/alloy steel |
+| Brass | `Brass` | Brass alloy |
+| Aluminum | `Al` | Aluminum alloy |
+
+#### Drive Style Abbreviations
+
+| Full Name | Abbreviation |
+|-----------|--------------|
+| Hex | `HEX` |
+| Phillips | `PH` |
+| Torx | `TX` |
+| Slotted | `SL` |
+
+### Dimension Formatting
+
+- **Fractions**: Automatically converted to decimals (`1/4"` → `0.25`)
+- **Inches**: Quote marks removed for cleaner names (`0.25"` → `0.25`)
+- **Metric**: Preserved as-is (`M6`, `20mm`)
+- **Thread Sizes**: Preserved as-is (`8-32`, `1/4-20`, `M6x1.0`)
+
+### Fallback Naming
+
+For unsupported categories, the system generates fallback names using:
+- Key words from the family description
+- Part number as suffix
+- Example: `BALL-BEARING-STEEL-12345A678`
+
+### Integration Examples
+
+#### BOM Usage
+```csv
+Part Number,Description,Generated Name,Quantity
+98164A133,316 SS Button Head Hex Drive Screw,BHCS-SS316-8-32-0.25-HEX,10
+91831A005,18-8 SS Nylon-Insert Locknut,LOCKNUT-SS188-4-40,10
+```
+
+#### Scripting
+```bash
+# Generate names for a list of parts
+for part in 98164A133 91831A005; do
+  echo "$part: $(mmc name $part)"
+done
+
+# Create part name lookup table
+mmc name 98164A133 > part_names.txt
+echo "98164A133 -> $(mmc name 98164A133)"
 ```
 
 ### Session Management

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ mmc name 98164A133
 # Output: BHS-SS316-8x32-0.25-HEX
 
 mmc name 90480A005  
-# Output: HEXNUT-Steel-4x40-ZP
+# Output: HN-S-4x40-ZP
 ```
 
 ### Supported Categories
@@ -215,11 +215,13 @@ mmc name 90480A005
 
 | Type | Template | Example Input | Generated Name |
 |------|----------|---------------|----------------|
-| Locknut | `LOCKNUT-[Material]-[Thread]-[Finish]` | 18-8 SS Nylon-Insert Locknut, 4x40 | `LOCKNUT-SS188-4x40` |
-| Hex Nut | `HEXNUT-[Material]-[Thread]-[Finish]` | 316 SS Hex Nut, 1/4x20, Zinc-Plated | `HEXNUT-SS316-1/4x20-ZP` |
-| Wing Nut | `WINGNUT-[Material]-[Thread]-[Finish]` | Brass Wing Nut, 8x32 | `WINGNUT-Brass-8x32` |
-| Cap Nut | `CAPNUT-[Material]-[Thread]-[Finish]` | SS Cap Nut, M8x1.25 | `CAPNUT-SS-M8x1.25` |
-| Generic Nut | `NUT-[Material]-[Thread]-[Finish]` | Steel Nut, 5/16x18 | `NUT-Steel-5/16x18` |
+| Locknut | `LN-[Material]-[Thread]-[Finish]` | 18-8 SS Nylon-Insert Locknut, 4x40 | `LN-SS188-4x40` |
+| Hex Nut | `HN-[Material]-[Thread]-[Finish]` | 316 SS Hex Nut, 1/4x20, Zinc-Plated | `HN-SS316-1/4x20-ZP` |
+| Wing Nut | `WN-[Material]-[Thread]-[Finish]` | Brass Wing Nut, 8x32 | `WN-Brass-8x32` |
+| Cap Nut | `CN-[Material]-[Thread]-[Finish]` | SS Cap Nut, M8x1.25 | `CN-SS-M8x1.25` |
+| Generic Nut | `N-[Material]-[Thread]-[Finish]` | Steel Nut, 5/16x18 | `N-S-5/16x18` |
+
+*Note: Supports 36+ nut types including Flange (FN), Socket (SN), Speed (SPEEDN), Square (SQN), and 11 specialized locking nut types. See code for complete list.*
 
 #### Washers
 
@@ -252,6 +254,16 @@ McMaster-Carr CLI supports 19 different washer types with specific naming patter
 
 *Note: The system automatically detects washer type from the family description and applies the appropriate template. If no specific type is detected, it defaults to flat washer naming.*
 
+#### Threaded Standoffs
+
+| Type | Template | Example Input | Generated Name |
+|------|----------|---------------|----------------|
+| Male-Female Standoff | `MFSO-[Material]-[Thread]-[Length]-[Finish]` | SS Male-Female Standoff, 4x40 x 0.5" | `MFSO-SS-4x40-0.5` |
+| Female Standoff | `FSO-[Material]-[Thread]-[Length]-[Finish]` | Brass Female Standoff, M6x1.0 x 25mm | `FSO-Brass-M6x1.0-25` |
+| Standoff (Generic) | `SO-[Material]-[Thread]-[Length]-[Finish]` | Aluminum Threaded Standoff, 8x32 x 0.75" | `SO-Al-8x32-0.75` |
+
+*Note: Supports various standoff configurations including male-female, female-only, and specialized types for electronics and mechanical assemblies.*
+
 #### Material Abbreviations
 
 | Full Name | Abbreviation | Notes |
@@ -259,7 +271,14 @@ McMaster-Carr CLI supports 19 different washer types with specific naming patter
 | 316 Stainless Steel | `SS316` | Marine grade, high corrosion resistance |
 | 18-8 Stainless Steel | `SS188` | Standard grade, good corrosion resistance |
 | Stainless Steel (generic) | `SS` | When specific grade not specified |
-| Steel | `Steel` | Carbon/alloy steel |
+| Grade 1 Steel | `SG1` | Low carbon steel |
+| Grade 2 Steel | `SG2` | Low carbon steel |
+| Grade 5 Steel | `SG5` | Medium carbon steel |
+| Grade 8 Steel | `SG8` | High strength alloy steel |
+| Class 8.8 Steel | `S8.8` | Metric medium strength |
+| Class 10.9 Steel | `S10.9` | Metric high strength |
+| Class 12.9 Steel | `S12.9` | Metric very high strength |
+| Steel (generic) | `S` | Carbon/alloy steel when grade not specified |
 | Brass | `Brass` | Brass alloy |
 | Aluminum | `Al` | Aluminum alloy |
 | Copper | `Cu` | Copper alloy |
@@ -318,7 +337,7 @@ For unsupported categories, the system generates fallback names using:
 ```csv
 Part Number,Description,Generated Name,Quantity
 98164A133,316 SS Button Head Hex Drive Screw,BHS-SS316-8x32-0.25-HEX,10
-90480A005,Low-Strength Steel Hex Nut,HEXNUT-Steel-4x40-ZP,10
+90480A005,Low-Strength Steel Hex Nut,HN-S-4x40-ZP,10
 ```
 
 #### Scripting

--- a/src/client.rs
+++ b/src/client.rs
@@ -1363,6 +1363,91 @@ impl NameGenerator {
             spec_abbreviations: standoff_abbrevs,
         };
         self.category_templates.insert("generic_standoff".to_string(), generic_standoff_template);
+        
+        // Bearing templates
+        let mut bearing_abbrevs = HashMap::new();
+        
+        // Material abbreviations for bearings
+        bearing_abbrevs.insert("MDS-Filled Nylon Plastic".to_string(), "MDSNYL".to_string());
+        bearing_abbrevs.insert("MDS-Filled Nylon".to_string(), "MDSNYL".to_string());
+        bearing_abbrevs.insert("Nylon Plastic".to_string(), "NYL".to_string());
+        bearing_abbrevs.insert("Bronze SAE 841".to_string(), "BR841".to_string());
+        bearing_abbrevs.insert("Bronze SAE 863".to_string(), "BR863".to_string());
+        bearing_abbrevs.insert("Cast Bronze".to_string(), "CB".to_string());
+        bearing_abbrevs.insert("Oil-Filled Bronze".to_string(), "OFB".to_string());
+        bearing_abbrevs.insert("PTFE".to_string(), "PTFE".to_string());
+        bearing_abbrevs.insert("Rulon".to_string(), "RUL".to_string());
+        bearing_abbrevs.insert("Graphite".to_string(), "GRAPH".to_string());
+        bearing_abbrevs.insert("Steel-Backed PTFE".to_string(), "SBPTFE".to_string());
+        bearing_abbrevs.insert("Bronze".to_string(), "BR".to_string());
+        bearing_abbrevs.insert("Steel".to_string(), "STL".to_string());
+        bearing_abbrevs.insert("Stainless Steel".to_string(), "SS".to_string());
+        bearing_abbrevs.insert("Aluminum".to_string(), "AL".to_string());
+        bearing_abbrevs.insert("Plastic".to_string(), "PL".to_string());
+        
+        // Flanged Sleeve Bearing
+        let flanged_sleeve_bearing_template = NamingTemplate {
+            prefix: "FSB".to_string(),
+            key_specs: vec!["Material".to_string(), "For Shaft Diameter".to_string(), "OD".to_string(), "Length".to_string()],
+            spec_abbreviations: bearing_abbrevs.clone(),
+        };
+        self.category_templates.insert("flanged_sleeve_bearing".to_string(), flanged_sleeve_bearing_template);
+        
+        // Plain Sleeve Bearing
+        let sleeve_bearing_template = NamingTemplate {
+            prefix: "SB".to_string(),
+            key_specs: vec!["Material".to_string(), "For Shaft Diameter".to_string(), "OD".to_string(), "Length".to_string()],
+            spec_abbreviations: bearing_abbrevs.clone(),
+        };
+        self.category_templates.insert("sleeve_bearing".to_string(), sleeve_bearing_template);
+        
+        // Flanged Bearing (generic)
+        let flanged_bearing_template = NamingTemplate {
+            prefix: "FB".to_string(),
+            key_specs: vec!["Material".to_string(), "For Shaft Diameter".to_string(), "OD".to_string(), "Length".to_string()],
+            spec_abbreviations: bearing_abbrevs.clone(),
+        };
+        self.category_templates.insert("flanged_bearing".to_string(), flanged_bearing_template);
+        
+        // Ball Bearing
+        let ball_bearing_template = NamingTemplate {
+            prefix: "BB".to_string(),
+            key_specs: vec!["Material".to_string(), "Bore".to_string(), "OD".to_string()],
+            spec_abbreviations: bearing_abbrevs.clone(),
+        };
+        self.category_templates.insert("ball_bearing".to_string(), ball_bearing_template);
+        
+        // Linear Bearing
+        let linear_bearing_template = NamingTemplate {
+            prefix: "LB".to_string(),
+            key_specs: vec!["Material".to_string(), "For Shaft Diameter".to_string(), "Length".to_string()],
+            spec_abbreviations: bearing_abbrevs.clone(),
+        };
+        self.category_templates.insert("linear_bearing".to_string(), linear_bearing_template);
+        
+        // Needle Bearing
+        let needle_bearing_template = NamingTemplate {
+            prefix: "NB".to_string(),
+            key_specs: vec!["Material".to_string(), "Bore".to_string(), "OD".to_string(), "Length".to_string()],
+            spec_abbreviations: bearing_abbrevs.clone(),
+        };
+        self.category_templates.insert("needle_bearing".to_string(), needle_bearing_template);
+        
+        // Roller Bearing
+        let roller_bearing_template = NamingTemplate {
+            prefix: "RB".to_string(),
+            key_specs: vec!["Material".to_string(), "Bore".to_string(), "OD".to_string(), "Length".to_string()],
+            spec_abbreviations: bearing_abbrevs.clone(),
+        };
+        self.category_templates.insert("roller_bearing".to_string(), roller_bearing_template);
+        
+        // Generic Bearing (fallback)
+        let generic_bearing_template = NamingTemplate {
+            prefix: "BRG".to_string(),
+            key_specs: vec!["Material".to_string(), "Type".to_string()],
+            spec_abbreviations: bearing_abbrevs,
+        };
+        self.category_templates.insert("generic_bearing".to_string(), generic_bearing_template);
     }
 
     pub fn generate_name(&self, product: &ProductDetail) -> String {
@@ -1628,6 +1713,33 @@ impl NameGenerator {
             } else {
                 "generic_standoff".to_string()
             }
+        } else if category_lower.contains("bearing") || family_lower.contains("bearing") {
+            // Determine specific bearing type
+            let plain_type = product.specifications.iter()
+                .find(|s| s.attribute.eq_ignore_ascii_case("Plain Bearing Type"))
+                .and_then(|s| s.values.first())
+                .map(|v| v.as_str())
+                .unwrap_or("");
+                
+            if family_lower.contains("flanged") || plain_type.eq_ignore_ascii_case("Flanged") {
+                if family_lower.contains("sleeve") || family_lower.contains("plain") {
+                    "flanged_sleeve_bearing".to_string()
+                } else {
+                    "flanged_bearing".to_string()
+                }
+            } else if family_lower.contains("sleeve") || family_lower.contains("plain") {
+                "sleeve_bearing".to_string()
+            } else if family_lower.contains("ball") {
+                "ball_bearing".to_string()
+            } else if family_lower.contains("linear") {
+                "linear_bearing".to_string()
+            } else if family_lower.contains("needle") {
+                "needle_bearing".to_string()
+            } else if family_lower.contains("roller") {
+                "roller_bearing".to_string()
+            } else {
+                "generic_bearing".to_string()
+            }
         } else {
             "unknown".to_string()
         }
@@ -1647,9 +1759,26 @@ impl NameGenerator {
                 if spec_name.eq_ignore_ascii_case("Material") {
                     let (material, finish) = self.parse_material_and_finish(&value);
                     
-                    // Check for steel grade to make steel more descriptive
-                    let final_material = if material.eq_ignore_ascii_case("Steel") || 
-                                           material.eq_ignore_ascii_case("Alloy Steel") {
+                    // Special handling for bearings with filler material
+                    let final_material = if template.prefix.ends_with("B") && (template.prefix.starts_with("FSB") || template.prefix.starts_with("SB") || template.prefix.starts_with("BB")) {
+                        // Check for filler material for bearings
+                        if let Some(filler_spec) = product.specifications.iter()
+                            .find(|s| s.attribute.eq_ignore_ascii_case("Filler Material")) {
+                            if let Some(filler_value) = filler_spec.values.first() {
+                                if !filler_value.is_empty() && filler_value != "None" && filler_value != "Not Specified" {
+                                    // Combine filler with base material
+                                    format!("{}-Filled {}", filler_value, material)
+                                } else {
+                                    material
+                                }
+                            } else {
+                                material
+                            }
+                        } else {
+                            material
+                        }
+                    } else if material.eq_ignore_ascii_case("Steel") || material.eq_ignore_ascii_case("Alloy Steel") {
+                        // Check for steel grade to make steel more descriptive
                         self.get_steel_grade_material(product, &material)
                     } else {
                         material
@@ -1688,6 +1817,16 @@ impl NameGenerator {
                     let abbreviated = template.spec_abbreviations.get(&length_value)
                         .cloned()
                         .unwrap_or(length_value);
+                    
+                    if !abbreviated.is_empty() {
+                        name_parts.push(abbreviated);
+                    }
+                } else if spec_name.eq_ignore_ascii_case("For Shaft Diameter") || spec_name.eq_ignore_ascii_case("OD") {
+                    // Special handling for bearing dimensions - convert fractions to decimals
+                    let dimension_value = self.convert_length_to_decimal(&value);
+                    let abbreviated = template.spec_abbreviations.get(&dimension_value)
+                        .cloned()
+                        .unwrap_or(dimension_value);
                     
                     if !abbreviated.is_empty() {
                         name_parts.push(abbreviated);

--- a/src/client.rs
+++ b/src/client.rs
@@ -113,6 +113,24 @@ impl NameGenerator {
         screw_abbrevs.insert("Brass".to_string(), "Brass".to_string());
         screw_abbrevs.insert("Aluminum".to_string(), "Al".to_string());
         
+        // Finish abbreviations for screws
+        screw_abbrevs.insert("Zinc Plated".to_string(), "ZP".to_string());
+        screw_abbrevs.insert("Zinc-Plated".to_string(), "ZP".to_string());
+        screw_abbrevs.insert("Zinc Yellow-Chromate Plated".to_string(), "ZYC".to_string());
+        screw_abbrevs.insert("Zinc Yellow Chromate Plated".to_string(), "ZYC".to_string());
+        screw_abbrevs.insert("Black Oxide".to_string(), "BO".to_string());
+        screw_abbrevs.insert("Black-Oxide".to_string(), "BO".to_string());
+        screw_abbrevs.insert("Passivated".to_string(), "PASS".to_string());
+        screw_abbrevs.insert("Plain".to_string(), "PLAIN".to_string());
+        screw_abbrevs.insert("Unfinished".to_string(), "UF".to_string());
+        screw_abbrevs.insert("Galvanized".to_string(), "GALV".to_string());
+        screw_abbrevs.insert("Cadmium Plated".to_string(), "CD".to_string());
+        screw_abbrevs.insert("Cadmium-Plated".to_string(), "CD".to_string());
+        screw_abbrevs.insert("Nickel Plated".to_string(), "NI".to_string());
+        screw_abbrevs.insert("Nickel-Plated".to_string(), "NI".to_string());
+        screw_abbrevs.insert("Chrome Plated".to_string(), "CR".to_string());
+        screw_abbrevs.insert("Chrome-Plated".to_string(), "CR".to_string());
+        
         // Drive style abbreviations (comprehensive list from McMaster-Carr)
         screw_abbrevs.insert("4-Flute Spline".to_string(), "4FS".to_string());
         screw_abbrevs.insert("6-Flute Spline".to_string(), "6FS".to_string());
@@ -168,6 +186,7 @@ impl NameGenerator {
                 "Thread Size".to_string(), 
                 "Length".to_string(),
                 "Drive Style".to_string(),
+                "Finish".to_string(),
             ],
             spec_abbreviations: screw_abbrevs.clone(),
         };
@@ -182,6 +201,7 @@ impl NameGenerator {
                 "Thread Size".to_string(), 
                 "Length".to_string(),
                 "Drive Style".to_string(),
+                "Finish".to_string(),
             ],
             spec_abbreviations: screw_abbrevs.clone(),
         };
@@ -196,6 +216,7 @@ impl NameGenerator {
                 "Thread Size".to_string(), 
                 "Length".to_string(),
                 "Drive Style".to_string(),
+                "Finish".to_string(),
             ],
             spec_abbreviations: screw_abbrevs.clone(),
         };
@@ -209,6 +230,7 @@ impl NameGenerator {
                 "Thread Size".to_string(), 
                 "Length".to_string(),
                 "Drive Style".to_string(),
+                "Finish".to_string(),
             ],
             spec_abbreviations: screw_abbrevs.clone(),
         };
@@ -222,6 +244,7 @@ impl NameGenerator {
                 "Thread Size".to_string(), 
                 "Length".to_string(),
                 "Drive Style".to_string(),
+                "Finish".to_string(),
             ],
             spec_abbreviations: screw_abbrevs.clone(),
         };
@@ -235,6 +258,7 @@ impl NameGenerator {
                 "Thread Size".to_string(), 
                 "Length".to_string(),
                 "Drive Style".to_string(),
+                "Finish".to_string(),
             ],
             spec_abbreviations: screw_abbrevs.clone(),
         };
@@ -248,6 +272,7 @@ impl NameGenerator {
                 "Thread Size".to_string(), 
                 "Length".to_string(),
                 "Drive Style".to_string(),
+                "Finish".to_string(),
             ],
             spec_abbreviations: screw_abbrevs.clone(),
         };
@@ -262,6 +287,7 @@ impl NameGenerator {
                 "Thread Size".to_string(), 
                 "Length".to_string(),
                 "Drive Style".to_string(),
+                "Finish".to_string(),
             ],
             spec_abbreviations: screw_abbrevs.clone(),
         };
@@ -275,6 +301,7 @@ impl NameGenerator {
                 "Thread Size".to_string(), 
                 "Length".to_string(),
                 "Drive Style".to_string(),
+                "Finish".to_string(),
             ],
             spec_abbreviations: screw_abbrevs.clone(),
         };
@@ -288,6 +315,7 @@ impl NameGenerator {
                 "Thread Size".to_string(), 
                 "Length".to_string(),
                 "Drive Style".to_string(),
+                "Finish".to_string(),
             ],
             spec_abbreviations: screw_abbrevs.clone(),
         };
@@ -301,6 +329,7 @@ impl NameGenerator {
                 "Thread Size".to_string(), 
                 "Length".to_string(),
                 "Drive Style".to_string(),
+                "Finish".to_string(),
             ],
             spec_abbreviations: screw_abbrevs.clone(),
         };
@@ -314,6 +343,7 @@ impl NameGenerator {
                 "Thread Size".to_string(), 
                 "Length".to_string(),
                 "Drive Style".to_string(),
+                "Finish".to_string(),
             ],
             spec_abbreviations: screw_abbrevs.clone(),
         };
@@ -335,7 +365,7 @@ impl NameGenerator {
         // 12-Point Head Screw
         let twelve_point_template = NamingTemplate {
             prefix: "12PHS".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("12_point_head_screw".to_string(), twelve_point_template);
@@ -343,7 +373,7 @@ impl NameGenerator {
         // Domed Head Screw
         let domed_template = NamingTemplate {
             prefix: "DHS".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("domed_head_screw".to_string(), domed_template);
@@ -351,7 +381,7 @@ impl NameGenerator {
         // Eye Screw
         let eye_template = NamingTemplate {
             prefix: "EYE".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("eye_screw".to_string(), eye_template);
@@ -359,7 +389,7 @@ impl NameGenerator {
         // Headless Screw (Set Screw)
         let headless_template = NamingTemplate {
             prefix: "HEADLESS".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("headless_screw".to_string(), headless_template);
@@ -367,7 +397,7 @@ impl NameGenerator {
         // Hex Head Screw
         let hex_head_template = NamingTemplate {
             prefix: "HHS".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("hex_head_screw".to_string(), hex_head_template);
@@ -375,7 +405,7 @@ impl NameGenerator {
         // Hook Screw
         let hook_template = NamingTemplate {
             prefix: "HOOK".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("hook_screw".to_string(), hook_template);
@@ -383,7 +413,7 @@ impl NameGenerator {
         // Knob Screw
         let knob_template = NamingTemplate {
             prefix: "KNOB".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("knob_screw".to_string(), knob_template);
@@ -391,7 +421,7 @@ impl NameGenerator {
         // L-Handle Screw
         let l_handle_template = NamingTemplate {
             prefix: "LHS".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("l_handle_screw".to_string(), l_handle_template);
@@ -399,7 +429,7 @@ impl NameGenerator {
         // Oval Head Screw
         let oval_template = NamingTemplate {
             prefix: "OHS".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("oval_head_screw".to_string(), oval_template);
@@ -408,7 +438,7 @@ impl NameGenerator {
         // Standard Oval Head Screw
         let standard_oval_template = NamingTemplate {
             prefix: "SOHS".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("standard_oval_head_screw".to_string(), standard_oval_template);
@@ -416,7 +446,7 @@ impl NameGenerator {
         // Undercut Oval Head Screw
         let undercut_oval_template = NamingTemplate {
             prefix: "UOHS".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("undercut_oval_head_screw".to_string(), undercut_oval_template);
@@ -424,7 +454,7 @@ impl NameGenerator {
         // Pentagon Head Screw
         let pentagon_head_template = NamingTemplate {
             prefix: "PENTHS".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("pentagon_head_screw".to_string(), pentagon_head_template);
@@ -432,7 +462,7 @@ impl NameGenerator {
         // Ring Screw
         let ring_template = NamingTemplate {
             prefix: "RING".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("ring_screw".to_string(), ring_template);
@@ -440,7 +470,7 @@ impl NameGenerator {
         // Rounded Head Screw
         let rounded_template = NamingTemplate {
             prefix: "RHS".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("rounded_head_screw".to_string(), rounded_template);
@@ -448,7 +478,7 @@ impl NameGenerator {
         // Square Head Screw
         let square_head_template = NamingTemplate {
             prefix: "SQHS".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("square_head_screw".to_string(), square_head_template);
@@ -456,7 +486,7 @@ impl NameGenerator {
         // Tee Screw
         let tee_template = NamingTemplate {
             prefix: "TEE".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("tee_screw".to_string(), tee_template);
@@ -464,7 +494,7 @@ impl NameGenerator {
         // T-Handle Screw
         let t_handle_template = NamingTemplate {
             prefix: "THS".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("t_handle_screw".to_string(), t_handle_template);
@@ -472,7 +502,7 @@ impl NameGenerator {
         // Threaded Screw
         let threaded_template = NamingTemplate {
             prefix: "THREADED".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("threaded_screw".to_string(), threaded_template);
@@ -480,7 +510,7 @@ impl NameGenerator {
         // Thumb Screw
         let thumb_template = NamingTemplate {
             prefix: "THUMB".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("thumb_screw".to_string(), thumb_template);
@@ -489,7 +519,7 @@ impl NameGenerator {
         // Four Arm Thumb Screw
         let four_arm_thumb_template = NamingTemplate {
             prefix: "4ARM".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("four_arm_thumb_screw".to_string(), four_arm_thumb_template);
@@ -497,7 +527,7 @@ impl NameGenerator {
         // Hex Thumb Screw
         let hex_thumb_template = NamingTemplate {
             prefix: "HEXTHUMB".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("hex_thumb_screw".to_string(), hex_thumb_template);
@@ -505,7 +535,7 @@ impl NameGenerator {
         // Multilobe Thumb Screw
         let multilobe_thumb_template = NamingTemplate {
             prefix: "MULTILOBE".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("multilobe_thumb_screw".to_string(), multilobe_thumb_template);
@@ -513,7 +543,7 @@ impl NameGenerator {
         // Rectangle Thumb Screw
         let rectangle_thumb_template = NamingTemplate {
             prefix: "RECTTHUMB".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("rectangle_thumb_screw".to_string(), rectangle_thumb_template);
@@ -521,7 +551,7 @@ impl NameGenerator {
         // Round Thumb Screw
         let round_thumb_template = NamingTemplate {
             prefix: "ROUNDTHUMB".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("round_thumb_screw".to_string(), round_thumb_template);
@@ -529,7 +559,7 @@ impl NameGenerator {
         // Spade Thumb Screw
         let spade_thumb_template = NamingTemplate {
             prefix: "SPADE".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("spade_thumb_screw".to_string(), spade_thumb_template);
@@ -537,7 +567,7 @@ impl NameGenerator {
         // Two Arm Thumb Screw
         let two_arm_thumb_template = NamingTemplate {
             prefix: "2ARM".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("two_arm_thumb_screw".to_string(), two_arm_thumb_template);
@@ -545,7 +575,7 @@ impl NameGenerator {
         // Wing Thumb Screw
         let wing_thumb_template = NamingTemplate {
             prefix: "WINGTHUMB".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("wing_thumb_screw".to_string(), wing_thumb_template);
@@ -553,7 +583,7 @@ impl NameGenerator {
         // T-Slot Screw
         let t_slot_template = NamingTemplate {
             prefix: "TSLOT".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("t_slot_screw".to_string(), t_slot_template);
@@ -562,7 +592,7 @@ impl NameGenerator {
         // Binding Head Screw
         let binding_head_template = NamingTemplate {
             prefix: "BINDING".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("binding_head_screw".to_string(), binding_head_template);
@@ -570,7 +600,7 @@ impl NameGenerator {
         // Carriage Head Screw
         let carriage_head_template = NamingTemplate {
             prefix: "CARRIAGE".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("carriage_head_screw".to_string(), carriage_head_template);
@@ -578,7 +608,7 @@ impl NameGenerator {
         // Cheese Head Screw
         let cheese_head_template = NamingTemplate {
             prefix: "CHEESE".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("cheese_head_screw".to_string(), cheese_head_template);
@@ -586,7 +616,7 @@ impl NameGenerator {
         // Fillister Head Screw
         let fillister_head_template = NamingTemplate {
             prefix: "FILLISTER".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("fillister_head_screw".to_string(), fillister_head_template);
@@ -594,7 +624,7 @@ impl NameGenerator {
         // Pancake Head Screw
         let pancake_head_template = NamingTemplate {
             prefix: "PANCAKE".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("pancake_head_screw".to_string(), pancake_head_template);
@@ -602,7 +632,7 @@ impl NameGenerator {
         // Round Head Screw
         let round_head_template = NamingTemplate {
             prefix: "ROUND".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("round_head_screw".to_string(), round_head_template);
@@ -610,7 +640,7 @@ impl NameGenerator {
         // Truss Head Screw
         let truss_head_template = NamingTemplate {
             prefix: "TRUSS".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("truss_head_screw".to_string(), truss_head_template);
@@ -839,12 +869,31 @@ impl NameGenerator {
         nut_abbrevs.insert("Brass".to_string(), "Brass".to_string());
         nut_abbrevs.insert("Aluminum".to_string(), "Al".to_string());
         
+        // Finish abbreviations for nuts
+        nut_abbrevs.insert("Zinc Plated".to_string(), "ZP".to_string());
+        nut_abbrevs.insert("Zinc-Plated".to_string(), "ZP".to_string());
+        nut_abbrevs.insert("Zinc Yellow-Chromate Plated".to_string(), "ZYC".to_string());
+        nut_abbrevs.insert("Zinc Yellow Chromate Plated".to_string(), "ZYC".to_string());
+        nut_abbrevs.insert("Black Oxide".to_string(), "BO".to_string());
+        nut_abbrevs.insert("Black-Oxide".to_string(), "BO".to_string());
+        nut_abbrevs.insert("Passivated".to_string(), "PASS".to_string());
+        nut_abbrevs.insert("Plain".to_string(), "PLAIN".to_string());
+        nut_abbrevs.insert("Unfinished".to_string(), "UF".to_string());
+        nut_abbrevs.insert("Galvanized".to_string(), "GALV".to_string());
+        nut_abbrevs.insert("Cadmium Plated".to_string(), "CD".to_string());
+        nut_abbrevs.insert("Cadmium-Plated".to_string(), "CD".to_string());
+        nut_abbrevs.insert("Nickel Plated".to_string(), "NI".to_string());
+        nut_abbrevs.insert("Nickel-Plated".to_string(), "NI".to_string());
+        nut_abbrevs.insert("Chrome Plated".to_string(), "CR".to_string());
+        nut_abbrevs.insert("Chrome-Plated".to_string(), "CR".to_string());
+        
         // Locknut template (nylon-insert, prevailing torque, etc.)
         let locknut_template = NamingTemplate {
             prefix: "LOCKNUT".to_string(),
             key_specs: vec![
                 "Material".to_string(),
                 "Thread Size".to_string(),
+                "Finish".to_string(),
             ],
             spec_abbreviations: nut_abbrevs.clone(),
         };
@@ -856,7 +905,7 @@ impl NameGenerator {
             key_specs: vec![
                 "Material".to_string(),
                 "Thread Size".to_string(),
-                "Height".to_string(),
+                "Finish".to_string(),
             ],
             spec_abbreviations: nut_abbrevs.clone(),
         };
@@ -868,6 +917,7 @@ impl NameGenerator {
             key_specs: vec![
                 "Material".to_string(),
                 "Thread Size".to_string(),
+                "Finish".to_string(),
             ],
             spec_abbreviations: nut_abbrevs.clone(),
         };
@@ -879,7 +929,7 @@ impl NameGenerator {
             key_specs: vec![
                 "Material".to_string(),
                 "Thread Size".to_string(),
-                "Height".to_string(),
+                "Finish".to_string(),
             ],
             spec_abbreviations: nut_abbrevs.clone(),
         };
@@ -891,6 +941,7 @@ impl NameGenerator {
             key_specs: vec![
                 "Material".to_string(),
                 "Thread Size".to_string(),
+                "Finish".to_string(),
             ],
             spec_abbreviations: nut_abbrevs,
         };
@@ -1115,7 +1166,8 @@ impl NameGenerator {
                         let finish_abbrev = template.spec_abbreviations.get(&finish_value)
                             .cloned()
                             .unwrap_or_else(|| self.abbreviate_value(&finish_value));
-                        if !finish_abbrev.is_empty() {
+                        // Skip passivated finish as it doesn't add meaningful information
+                        if !finish_abbrev.is_empty() && finish_abbrev != "PASS" {
                             name_parts.push(finish_abbrev);
                         }
                     }
@@ -1135,7 +1187,8 @@ impl NameGenerator {
                 let finish_abbrev = template.spec_abbreviations.get(&finish_value)
                     .cloned()
                     .unwrap_or_else(|| self.abbreviate_value(&finish_value));
-                if !finish_abbrev.is_empty() {
+                // Skip passivated finish as it doesn't add meaningful information
+                if !finish_abbrev.is_empty() && finish_abbrev != "PASS" {
                     name_parts.push(finish_abbrev);
                 }
             }
@@ -1147,8 +1200,10 @@ impl NameGenerator {
     fn parse_material_and_finish(&self, material_value: &str) -> (String, Option<String>) {
         // Common finish prefixes that can appear in material specifications
         let finish_prefixes = [
-            "Black-Oxide ", "Black Oxide ", "Zinc Plated ", "Zinc Yellow-Chromate Plated ",
-            "Galvanized ", "Cadmium Plated ", "Nickel Plated ", "Chrome Plated ",
+            "Black-Oxide ", "Black Oxide ", "Zinc Plated ", "Zinc-Plated ", 
+            "Zinc Yellow-Chromate Plated ", "Zinc Yellow Chromate Plated ",
+            "Galvanized ", "Cadmium Plated ", "Cadmium-Plated ", 
+            "Nickel Plated ", "Nickel-Plated ", "Chrome Plated ", "Chrome-Plated ",
             "Passivated ", "Plain ", "Unfinished "
         ];
         

--- a/src/client.rs
+++ b/src/client.rs
@@ -107,6 +107,7 @@ impl NameGenerator {
         
         // Material abbreviations
         screw_abbrevs.insert("316 Stainless Steel".to_string(), "SS316".to_string());
+        screw_abbrevs.insert("18-8 Stainless Steel".to_string(), "SS188".to_string());
         screw_abbrevs.insert("Stainless Steel".to_string(), "SS".to_string());
         screw_abbrevs.insert("Steel".to_string(), "Steel".to_string());
         screw_abbrevs.insert("Brass".to_string(), "Brass".to_string());
@@ -173,6 +174,7 @@ impl NameGenerator {
         // Washer template
         let mut washer_abbrevs = HashMap::new();
         washer_abbrevs.insert("316 Stainless Steel".to_string(), "SS316".to_string());
+        washer_abbrevs.insert("18-8 Stainless Steel".to_string(), "SS188".to_string());
         washer_abbrevs.insert("Stainless Steel".to_string(), "SS".to_string());
         washer_abbrevs.insert("Steel".to_string(), "Steel".to_string());
         washer_abbrevs.insert("Brass".to_string(), "Brass".to_string());
@@ -187,6 +189,72 @@ impl NameGenerator {
             spec_abbreviations: washer_abbrevs,
         };
         self.category_templates.insert("washer".to_string(), washer_template);
+        
+        // Nut templates
+        let mut nut_abbrevs = HashMap::new();
+        nut_abbrevs.insert("316 Stainless Steel".to_string(), "SS316".to_string());
+        nut_abbrevs.insert("18-8 Stainless Steel".to_string(), "SS188".to_string());
+        nut_abbrevs.insert("Stainless Steel".to_string(), "SS".to_string());
+        nut_abbrevs.insert("Steel".to_string(), "Steel".to_string());
+        nut_abbrevs.insert("Brass".to_string(), "Brass".to_string());
+        nut_abbrevs.insert("Aluminum".to_string(), "Al".to_string());
+        
+        // Locknut template (nylon-insert, prevailing torque, etc.)
+        let locknut_template = NamingTemplate {
+            prefix: "LOCKNUT".to_string(),
+            key_specs: vec![
+                "Material".to_string(),
+                "Thread Size".to_string(),
+            ],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("locknut".to_string(), locknut_template);
+        
+        // Hex nut template
+        let hex_nut_template = NamingTemplate {
+            prefix: "HEXNUT".to_string(),
+            key_specs: vec![
+                "Material".to_string(),
+                "Thread Size".to_string(),
+                "Height".to_string(),
+            ],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("hex_nut".to_string(), hex_nut_template);
+        
+        // Wing nut template
+        let wing_nut_template = NamingTemplate {
+            prefix: "WINGNUT".to_string(),
+            key_specs: vec![
+                "Material".to_string(),
+                "Thread Size".to_string(),
+            ],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("wing_nut".to_string(), wing_nut_template);
+        
+        // Cap nut template
+        let cap_nut_template = NamingTemplate {
+            prefix: "CAPNUT".to_string(),
+            key_specs: vec![
+                "Material".to_string(),
+                "Thread Size".to_string(),
+                "Height".to_string(),
+            ],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("cap_nut".to_string(), cap_nut_template);
+        
+        // Generic nut template
+        let generic_nut_template = NamingTemplate {
+            prefix: "NUT".to_string(),
+            key_specs: vec![
+                "Material".to_string(),
+                "Thread Size".to_string(),
+            ],
+            spec_abbreviations: nut_abbrevs,
+        };
+        self.category_templates.insert("generic_nut".to_string(), generic_nut_template);
     }
 
     pub fn generate_name(&self, product: &ProductDetail) -> String {
@@ -217,6 +285,20 @@ impl NameGenerator {
             "generic_screw".to_string()
         } else if category_lower.contains("washer") || family_lower.contains("washer") {
             "washer".to_string()
+        } else if category_lower.contains("nuts") || category_lower.contains("nut") || family_lower.contains("nut") {
+            // Determine specific nut type
+            if family_lower.contains("locknut") || family_lower.contains("lock nut") || 
+               family_lower.contains("nylon-insert") || family_lower.contains("prevailing torque") {
+                "locknut".to_string()
+            } else if family_lower.contains("hex nut") || family_lower.contains("hexnut") {
+                "hex_nut".to_string()
+            } else if family_lower.contains("wing nut") || family_lower.contains("wingnut") {
+                "wing_nut".to_string()
+            } else if family_lower.contains("cap nut") || family_lower.contains("capnut") {
+                "cap_nut".to_string()
+            } else {
+                "generic_nut".to_string()
+            }
         } else {
             "unknown".to_string()
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -615,24 +615,220 @@ impl NameGenerator {
         };
         self.category_templates.insert("truss_head_screw".to_string(), truss_head_template);
         
-        // Washer template
+        // Washer templates - comprehensive support for all washer types
         let mut washer_abbrevs = HashMap::new();
         washer_abbrevs.insert("316 Stainless Steel".to_string(), "SS316".to_string());
         washer_abbrevs.insert("18-8 Stainless Steel".to_string(), "SS188".to_string());
         washer_abbrevs.insert("Stainless Steel".to_string(), "SS".to_string());
         washer_abbrevs.insert("Steel".to_string(), "Steel".to_string());
         washer_abbrevs.insert("Brass".to_string(), "Brass".to_string());
+        washer_abbrevs.insert("Aluminum".to_string(), "Al".to_string());
+        washer_abbrevs.insert("Copper".to_string(), "Cu".to_string());
+        washer_abbrevs.insert("Nylon".to_string(), "Nylon".to_string());
+        washer_abbrevs.insert("Plastic".to_string(), "Plastic".to_string());
+        washer_abbrevs.insert("Rubber".to_string(), "Rubber".to_string());
         
-        let washer_template = NamingTemplate {
-            prefix: "WASHER".to_string(),
-            key_specs: vec![
-                "Material".to_string(),
-                "Inside Diameter".to_string(),
-                "Outside Diameter".to_string(),
-            ],
-            spec_abbreviations: washer_abbrevs,
+        // Screw size abbreviations for washers
+        washer_abbrevs.insert("No. 0".to_string(), "0".to_string());
+        washer_abbrevs.insert("No. 1".to_string(), "1".to_string());
+        washer_abbrevs.insert("No. 2".to_string(), "2".to_string());
+        washer_abbrevs.insert("No. 3".to_string(), "3".to_string());
+        washer_abbrevs.insert("No. 4".to_string(), "4".to_string());
+        washer_abbrevs.insert("No. 5".to_string(), "5".to_string());
+        washer_abbrevs.insert("No. 6".to_string(), "6".to_string());
+        washer_abbrevs.insert("No. 8".to_string(), "8".to_string());
+        washer_abbrevs.insert("No. 10".to_string(), "10".to_string());
+        washer_abbrevs.insert("No. 12".to_string(), "12".to_string());
+        washer_abbrevs.insert("No. 14".to_string(), "14".to_string());
+        
+        // Finish abbreviations for washers
+        washer_abbrevs.insert("Zinc Plated".to_string(), "ZP".to_string());
+        washer_abbrevs.insert("Zinc Yellow-Chromate Plated".to_string(), "ZYC".to_string());
+        washer_abbrevs.insert("Black Oxide".to_string(), "BO".to_string());
+        washer_abbrevs.insert("Black-Oxide".to_string(), "BO".to_string());
+        washer_abbrevs.insert("Passivated".to_string(), "PASS".to_string());
+        washer_abbrevs.insert("Plain".to_string(), "PLAIN".to_string());
+        washer_abbrevs.insert("Unfinished".to_string(), "UF".to_string());
+        washer_abbrevs.insert("Galvanized".to_string(), "GALV".to_string());
+        washer_abbrevs.insert("Cadmium Plated".to_string(), "CD".to_string());
+        washer_abbrevs.insert("Nickel Plated".to_string(), "NI".to_string());
+        washer_abbrevs.insert("Chrome Plated".to_string(), "CR".to_string());
+        
+        // Cup Washer
+        let cup_washer_template = NamingTemplate {
+            prefix: "CW".to_string(),
+            key_specs: vec!["Material".to_string(), "For Screw Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: washer_abbrevs.clone(),
         };
-        self.category_templates.insert("washer".to_string(), washer_template);
+        self.category_templates.insert("cup_washer".to_string(), cup_washer_template);
+        
+        // Curved Washer
+        let curved_washer_template = NamingTemplate {
+            prefix: "CRVW".to_string(),
+            key_specs: vec!["Material".to_string(), "For Screw Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: washer_abbrevs.clone(),
+        };
+        self.category_templates.insert("curved_washer".to_string(), curved_washer_template);
+        
+        // Dished Washer
+        let dished_washer_template = NamingTemplate {
+            prefix: "DW".to_string(),
+            key_specs: vec!["Material".to_string(), "For Screw Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: washer_abbrevs.clone(),
+        };
+        self.category_templates.insert("dished_washer".to_string(), dished_washer_template);
+        
+        // Domed Washer
+        let domed_washer_template = NamingTemplate {
+            prefix: "DMW".to_string(),
+            key_specs: vec!["Material".to_string(), "For Screw Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: washer_abbrevs.clone(),
+        };
+        self.category_templates.insert("domed_washer".to_string(), domed_washer_template);
+        
+        // Double Clipped Washer
+        let double_clipped_washer_template = NamingTemplate {
+            prefix: "DCW".to_string(),
+            key_specs: vec!["Material".to_string(), "For Screw Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: washer_abbrevs.clone(),
+        };
+        self.category_templates.insert("double_clipped_washer".to_string(), double_clipped_washer_template);
+        
+        // Clipped Washer (single clipped)
+        let clipped_washer_template = NamingTemplate {
+            prefix: "CLW".to_string(),
+            key_specs: vec!["Material".to_string(), "For Screw Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: washer_abbrevs.clone(),
+        };
+        self.category_templates.insert("clipped_washer".to_string(), clipped_washer_template);
+        
+        // Flat Washer (default/standard)
+        let flat_washer_template = NamingTemplate {
+            prefix: "FW".to_string(),
+            key_specs: vec!["Material".to_string(), "For Screw Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: washer_abbrevs.clone(),
+        };
+        self.category_templates.insert("flat_washer".to_string(), flat_washer_template);
+        
+        // Hillside Washer
+        let hillside_washer_template = NamingTemplate {
+            prefix: "HW".to_string(),
+            key_specs: vec!["Material".to_string(), "For Screw Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: washer_abbrevs.clone(),
+        };
+        self.category_templates.insert("hillside_washer".to_string(), hillside_washer_template);
+        
+        // Notched Washer
+        let notched_washer_template = NamingTemplate {
+            prefix: "NW".to_string(),
+            key_specs: vec!["Material".to_string(), "For Screw Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: washer_abbrevs.clone(),
+        };
+        self.category_templates.insert("notched_washer".to_string(), notched_washer_template);
+        
+        // Perforated Washer
+        let perforated_washer_template = NamingTemplate {
+            prefix: "PW".to_string(),
+            key_specs: vec!["Material".to_string(), "For Screw Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: washer_abbrevs.clone(),
+        };
+        self.category_templates.insert("perforated_washer".to_string(), perforated_washer_template);
+        
+        // Pronged Washer
+        let pronged_washer_template = NamingTemplate {
+            prefix: "PRW".to_string(),
+            key_specs: vec!["Material".to_string(), "For Screw Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: washer_abbrevs.clone(),
+        };
+        self.category_templates.insert("pronged_washer".to_string(), pronged_washer_template);
+        
+        // Rectangular Washer
+        let rectangular_washer_template = NamingTemplate {
+            prefix: "RW".to_string(),
+            key_specs: vec!["Material".to_string(), "For Screw Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: washer_abbrevs.clone(),
+        };
+        self.category_templates.insert("rectangular_washer".to_string(), rectangular_washer_template);
+        
+        // Sleeve Washer
+        let sleeve_washer_template = NamingTemplate {
+            prefix: "SW".to_string(),
+            key_specs: vec!["Material".to_string(), "For Screw Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: washer_abbrevs.clone(),
+        };
+        self.category_templates.insert("sleeve_washer".to_string(), sleeve_washer_template);
+        
+        // Slotted Washer
+        let slotted_washer_template = NamingTemplate {
+            prefix: "SLW".to_string(),
+            key_specs: vec!["Material".to_string(), "For Screw Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: washer_abbrevs.clone(),
+        };
+        self.category_templates.insert("slotted_washer".to_string(), slotted_washer_template);
+        
+        // Spherical Washer
+        let spherical_washer_template = NamingTemplate {
+            prefix: "SPW".to_string(),
+            key_specs: vec!["Material".to_string(), "For Screw Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: washer_abbrevs.clone(),
+        };
+        self.category_templates.insert("spherical_washer".to_string(), spherical_washer_template);
+        
+        // Split Washer (Lock Washer)
+        let split_washer_template = NamingTemplate {
+            prefix: "SPLW".to_string(),
+            key_specs: vec!["Material".to_string(), "For Screw Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: washer_abbrevs.clone(),
+        };
+        self.category_templates.insert("split_washer".to_string(), split_washer_template);
+        
+        // Square Washer
+        let square_washer_template = NamingTemplate {
+            prefix: "SQW".to_string(),
+            key_specs: vec!["Material".to_string(), "For Screw Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: washer_abbrevs.clone(),
+        };
+        self.category_templates.insert("square_washer".to_string(), square_washer_template);
+        
+        // Tab Washer
+        let tab_washer_template = NamingTemplate {
+            prefix: "TW".to_string(),
+            key_specs: vec!["Material".to_string(), "For Screw Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: washer_abbrevs.clone(),
+        };
+        self.category_templates.insert("tab_washer".to_string(), tab_washer_template);
+        
+        // Tapered Washer
+        let tapered_washer_template = NamingTemplate {
+            prefix: "TPW".to_string(),
+            key_specs: vec!["Material".to_string(), "For Screw Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: washer_abbrevs.clone(),
+        };
+        self.category_templates.insert("tapered_washer".to_string(), tapered_washer_template);
+        
+        // Tooth Washer
+        let tooth_washer_template = NamingTemplate {
+            prefix: "TOW".to_string(),
+            key_specs: vec!["Material".to_string(), "For Screw Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: washer_abbrevs.clone(),
+        };
+        self.category_templates.insert("tooth_washer".to_string(), tooth_washer_template);
+        
+        // Wave Washer
+        let wave_washer_template = NamingTemplate {
+            prefix: "WW".to_string(),
+            key_specs: vec!["Material".to_string(), "For Screw Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: washer_abbrevs.clone(),
+        };
+        self.category_templates.insert("wave_washer".to_string(), wave_washer_template);
+        
+        // Wedge Washer
+        let wedge_washer_template = NamingTemplate {
+            prefix: "WDW".to_string(),
+            key_specs: vec!["Material".to_string(), "For Screw Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: washer_abbrevs.clone(),
+        };
+        self.category_templates.insert("wedge_washer".to_string(), wedge_washer_template);
         
         // Nut templates
         let mut nut_abbrevs = HashMap::new();
@@ -816,7 +1012,54 @@ impl NameGenerator {
         } else if category_lower.contains("screw") || family_lower.contains("screw") {
             "generic_screw".to_string()
         } else if category_lower.contains("washer") || family_lower.contains("washer") {
-            "washer".to_string()
+            // Determine specific washer type
+            if family_lower.contains("cup") {
+                "cup_washer".to_string()
+            } else if family_lower.contains("curved") {
+                "curved_washer".to_string()
+            } else if family_lower.contains("dished") {
+                "dished_washer".to_string()
+            } else if family_lower.contains("domed") {
+                "domed_washer".to_string()
+            } else if family_lower.contains("double clipped") {
+                "double_clipped_washer".to_string()
+            } else if family_lower.contains("clipped") {
+                "clipped_washer".to_string()
+            } else if family_lower.contains("flat") {
+                "flat_washer".to_string()
+            } else if family_lower.contains("hillside") {
+                "hillside_washer".to_string()
+            } else if family_lower.contains("notched") {
+                "notched_washer".to_string()
+            } else if family_lower.contains("perforated") {
+                "perforated_washer".to_string()
+            } else if family_lower.contains("pronged") {
+                "pronged_washer".to_string()
+            } else if family_lower.contains("rectangular") {
+                "rectangular_washer".to_string()
+            } else if family_lower.contains("sleeve") {
+                "sleeve_washer".to_string()
+            } else if family_lower.contains("slotted") {
+                "slotted_washer".to_string()
+            } else if family_lower.contains("spherical") {
+                "spherical_washer".to_string()
+            } else if family_lower.contains("split") {
+                "split_washer".to_string()
+            } else if family_lower.contains("square") {
+                "square_washer".to_string()
+            } else if family_lower.contains("tab") {
+                "tab_washer".to_string()
+            } else if family_lower.contains("tapered") {
+                "tapered_washer".to_string()
+            } else if family_lower.contains("tooth") {
+                "tooth_washer".to_string()
+            } else if family_lower.contains("wave") {
+                "wave_washer".to_string()
+            } else if family_lower.contains("wedge") {
+                "wedge_washer".to_string()
+            } else {
+                "flat_washer".to_string() // Default to flat washer
+            }
         } else if category_lower.contains("nuts") || category_lower.contains("nut") || family_lower.contains("nut") {
             // Determine specific nut type
             if family_lower.contains("locknut") || family_lower.contains("lock nut") || 
@@ -838,6 +1081,7 @@ impl NameGenerator {
 
     fn apply_template(&self, product: &ProductDetail, template: &NamingTemplate) -> String {
         let mut name_parts = vec![template.prefix.clone()];
+        let mut extracted_finish: Option<String> = None;
         
         for spec_name in &template.key_specs {
             if let Some(spec) = product.specifications.iter()
@@ -845,13 +1089,54 @@ impl NameGenerator {
                 
                 let value = spec.values.first().unwrap_or(&"".to_string()).clone();
                 
-                // Apply abbreviation if available
-                let abbreviated = template.spec_abbreviations.get(&value)
+                // Special handling for Material that might include finish
+                if spec_name.eq_ignore_ascii_case("Material") {
+                    let (material, finish) = self.parse_material_and_finish(&value);
+                    
+                    // Add material abbreviation
+                    let material_abbrev = template.spec_abbreviations.get(&material)
+                        .cloned()
+                        .unwrap_or_else(|| self.abbreviate_value(&material));
+                    if !material_abbrev.is_empty() {
+                        name_parts.push(material_abbrev);
+                    }
+                    
+                    // Store extracted finish for later use
+                    extracted_finish = finish;
+                } else if spec_name.eq_ignore_ascii_case("Finish") {
+                    // Check if we have a separate finish spec, or use the extracted one
+                    let finish_value = if !value.is_empty() {
+                        value.clone()
+                    } else {
+                        extracted_finish.clone().unwrap_or_default()
+                    };
+                    
+                    if !finish_value.is_empty() {
+                        let finish_abbrev = template.spec_abbreviations.get(&finish_value)
+                            .cloned()
+                            .unwrap_or_else(|| self.abbreviate_value(&finish_value));
+                        if !finish_abbrev.is_empty() {
+                            name_parts.push(finish_abbrev);
+                        }
+                    }
+                } else {
+                    // Normal handling for other specs
+                    let abbreviated = template.spec_abbreviations.get(&value)
+                        .cloned()
+                        .unwrap_or_else(|| self.abbreviate_value(&value));
+                    
+                    if !abbreviated.is_empty() {
+                        name_parts.push(abbreviated);
+                    }
+                }
+            } else if spec_name.eq_ignore_ascii_case("Finish") && extracted_finish.is_some() {
+                // Handle case where there's no "Finish" attribute but we extracted finish from material
+                let finish_value = extracted_finish.clone().unwrap();
+                let finish_abbrev = template.spec_abbreviations.get(&finish_value)
                     .cloned()
-                    .unwrap_or_else(|| self.abbreviate_value(&value));
-                
-                if !abbreviated.is_empty() {
-                    name_parts.push(abbreviated);
+                    .unwrap_or_else(|| self.abbreviate_value(&finish_value));
+                if !finish_abbrev.is_empty() {
+                    name_parts.push(finish_abbrev);
                 }
             }
         }
@@ -859,18 +1144,30 @@ impl NameGenerator {
         name_parts.join("-")
     }
 
+    fn parse_material_and_finish(&self, material_value: &str) -> (String, Option<String>) {
+        // Common finish prefixes that can appear in material specifications
+        let finish_prefixes = [
+            "Black-Oxide ", "Black Oxide ", "Zinc Plated ", "Zinc Yellow-Chromate Plated ",
+            "Galvanized ", "Cadmium Plated ", "Nickel Plated ", "Chrome Plated ",
+            "Passivated ", "Plain ", "Unfinished "
+        ];
+        
+        for prefix in &finish_prefixes {
+            if material_value.starts_with(prefix) {
+                let finish = prefix.trim().to_string();
+                let material = material_value.strip_prefix(prefix).unwrap_or(material_value).to_string();
+                return (material, Some(finish));
+            }
+        }
+        
+        // No finish prefix found, return the whole value as material
+        (material_value.to_string(), None)
+    }
+
     fn abbreviate_value(&self, value: &str) -> String {
         // Handle common dimension formats
         if value.contains("\"") {
-            // Convert fractions to decimals for consistency
-            if value == "1/4\"" {
-                return "0.25".to_string();
-            } else if value == "1/2\"" {
-                return "0.5".to_string();
-            } else if value == "3/4\"" {
-                return "0.75".to_string();
-            }
-            // Remove quotes and return
+            // Keep fractions as-is, just remove quotes
             value.replace("\"", "").to_string()
         } else {
             // Return as-is for thread sizes and other values
@@ -2064,8 +2361,51 @@ certificate_password = "certificate_password"
                 return Err(anyhow::anyhow!("Failed to parse product data for name generation"));
             }
         } else if response.status().as_u16() == 403 {
+            // Product is not in subscription - offer to add it
             println!("❌ Product {} is not in your subscription.", product);
-            return Err(anyhow::anyhow!("Product not in subscription. Add it first with: mmc add {}", product));
+            print!("Would you like to add it to your subscription? (Y/n): ");
+            io::stdout().flush().unwrap();
+            
+            let mut input = String::new();
+            io::stdin().read_line(&mut input).unwrap();
+            let input = input.trim().to_lowercase();
+            
+            if input == "y" || input == "yes" || input.is_empty() {
+                println!("Adding product {} to subscription...", product);
+                self.add_product(product).await?;
+                println!("✅ Product added! Generating name...");
+                
+                // Retry the product request after adding to subscription
+                let url = format!("{}/v1/products/{}", BASE_URL, product);
+                let response = self
+                    .client
+                    .get(&url)
+                    .bearer_auth(self.token.as_ref().unwrap())
+                    .send()
+                    .await
+                    .context("Failed to get product after adding to subscription")?;
+                
+                if response.status().is_success() {
+                    let response_text = response.text().await.context("Failed to get response text")?;
+                    
+                    if let Ok(product_detail) = serde_json::from_str::<ProductDetail>(&response_text) {
+                        let human_name = self.name_generator.generate_name(&product_detail);
+                        println!("{}", human_name);
+                    } else {
+                        return Err(anyhow::anyhow!("Failed to parse product data for name generation"));
+                    }
+                } else {
+                    return Err(anyhow::anyhow!(
+                        "Failed to get product {} after adding to subscription. Status: {}",
+                        product, response.status()
+                    ));
+                }
+            } else {
+                return Err(anyhow::anyhow!(
+                    "Product {} is not in your subscription. Add it first with: mmc add {}",
+                    product, product
+                ));
+            }
         } else {
             let status = response.status();
             let error_text = response.text().await.unwrap_or_default();

--- a/src/client.rs
+++ b/src/client.rs
@@ -397,7 +397,7 @@ impl NameGenerator {
         // Hex Head Screw
         let hex_head_template = NamingTemplate {
             prefix: "HHS".to_string(),
-            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Finish".to_string()],
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string(), "Finish".to_string()],
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("hex_head_screw".to_string(), hex_head_template);

--- a/src/client.rs
+++ b/src/client.rs
@@ -110,6 +110,7 @@ impl NameGenerator {
         screw_abbrevs.insert("18-8 Stainless Steel".to_string(), "SS188".to_string());
         screw_abbrevs.insert("Stainless Steel".to_string(), "SS".to_string());
         screw_abbrevs.insert("Steel".to_string(), "S".to_string());
+        screw_abbrevs.insert("Alloy Steel".to_string(), "S".to_string());
         
         // Steel grade abbreviations
         screw_abbrevs.insert("Grade 1 Steel".to_string(), "SG1".to_string());
@@ -119,6 +120,15 @@ impl NameGenerator {
         screw_abbrevs.insert("8.8 Steel".to_string(), "S8.8".to_string());
         screw_abbrevs.insert("10.9 Steel".to_string(), "S10.9".to_string());
         screw_abbrevs.insert("12.9 Steel".to_string(), "S12.9".to_string());
+        
+        // Alloy steel grade abbreviations
+        screw_abbrevs.insert("Grade 1 Alloy Steel".to_string(), "SG1".to_string());
+        screw_abbrevs.insert("Grade 2 Alloy Steel".to_string(), "SG2".to_string());
+        screw_abbrevs.insert("Grade 5 Alloy Steel".to_string(), "SG5".to_string());
+        screw_abbrevs.insert("Grade 8 Alloy Steel".to_string(), "SG8".to_string());
+        screw_abbrevs.insert("8.8 Alloy Steel".to_string(), "S8.8".to_string());
+        screw_abbrevs.insert("10.9 Alloy Steel".to_string(), "S10.9".to_string());
+        screw_abbrevs.insert("12.9 Alloy Steel".to_string(), "S12.9".to_string());
         screw_abbrevs.insert("Brass".to_string(), "Brass".to_string());
         screw_abbrevs.insert("Aluminum".to_string(), "Al".to_string());
         
@@ -660,6 +670,7 @@ impl NameGenerator {
         washer_abbrevs.insert("18-8 Stainless Steel".to_string(), "SS188".to_string());
         washer_abbrevs.insert("Stainless Steel".to_string(), "SS".to_string());
         washer_abbrevs.insert("Steel".to_string(), "S".to_string());
+        washer_abbrevs.insert("Alloy Steel".to_string(), "S".to_string());
         
         // Steel grade abbreviations for washers
         washer_abbrevs.insert("Grade 1 Steel".to_string(), "SG1".to_string());
@@ -669,6 +680,15 @@ impl NameGenerator {
         washer_abbrevs.insert("8.8 Steel".to_string(), "S8.8".to_string());
         washer_abbrevs.insert("10.9 Steel".to_string(), "S10.9".to_string());
         washer_abbrevs.insert("12.9 Steel".to_string(), "S12.9".to_string());
+        
+        // Alloy steel grade abbreviations for washers
+        washer_abbrevs.insert("Grade 1 Alloy Steel".to_string(), "SG1".to_string());
+        washer_abbrevs.insert("Grade 2 Alloy Steel".to_string(), "SG2".to_string());
+        washer_abbrevs.insert("Grade 5 Alloy Steel".to_string(), "SG5".to_string());
+        washer_abbrevs.insert("Grade 8 Alloy Steel".to_string(), "SG8".to_string());
+        washer_abbrevs.insert("8.8 Alloy Steel".to_string(), "S8.8".to_string());
+        washer_abbrevs.insert("10.9 Alloy Steel".to_string(), "S10.9".to_string());
+        washer_abbrevs.insert("12.9 Alloy Steel".to_string(), "S12.9".to_string());
         washer_abbrevs.insert("Brass".to_string(), "Brass".to_string());
         washer_abbrevs.insert("Aluminum".to_string(), "Al".to_string());
         washer_abbrevs.insert("Copper".to_string(), "Cu".to_string());
@@ -884,6 +904,7 @@ impl NameGenerator {
         nut_abbrevs.insert("18-8 Stainless Steel".to_string(), "SS188".to_string());
         nut_abbrevs.insert("Stainless Steel".to_string(), "SS".to_string());
         nut_abbrevs.insert("Steel".to_string(), "S".to_string());
+        nut_abbrevs.insert("Alloy Steel".to_string(), "S".to_string());
         
         // Steel grade abbreviations for nuts
         nut_abbrevs.insert("Grade 1 Steel".to_string(), "SG1".to_string());
@@ -893,6 +914,15 @@ impl NameGenerator {
         nut_abbrevs.insert("8.8 Steel".to_string(), "S8.8".to_string());
         nut_abbrevs.insert("10.9 Steel".to_string(), "S10.9".to_string());
         nut_abbrevs.insert("12.9 Steel".to_string(), "S12.9".to_string());
+        
+        // Alloy steel grade abbreviations for nuts
+        nut_abbrevs.insert("Grade 1 Alloy Steel".to_string(), "SG1".to_string());
+        nut_abbrevs.insert("Grade 2 Alloy Steel".to_string(), "SG2".to_string());
+        nut_abbrevs.insert("Grade 5 Alloy Steel".to_string(), "SG5".to_string());
+        nut_abbrevs.insert("Grade 8 Alloy Steel".to_string(), "SG8".to_string());
+        nut_abbrevs.insert("8.8 Alloy Steel".to_string(), "S8.8".to_string());
+        nut_abbrevs.insert("10.9 Alloy Steel".to_string(), "S10.9".to_string());
+        nut_abbrevs.insert("12.9 Alloy Steel".to_string(), "S12.9".to_string());
         nut_abbrevs.insert("Brass".to_string(), "Brass".to_string());
         nut_abbrevs.insert("Aluminum".to_string(), "Al".to_string());
         
@@ -1540,7 +1570,8 @@ impl NameGenerator {
                     let (material, finish) = self.parse_material_and_finish(&value);
                     
                     // Check for steel grade to make steel more descriptive
-                    let final_material = if material.eq_ignore_ascii_case("Steel") {
+                    let final_material = if material.eq_ignore_ascii_case("Steel") || 
+                                           material.eq_ignore_ascii_case("Alloy Steel") {
                         self.get_steel_grade_material(product, &material)
                     } else {
                         material
@@ -1692,21 +1723,28 @@ impl NameGenerator {
                      s.attribute.contains("Strength")) 
         {
             if let Some(grade_value) = grade_spec.values.first() {
+                // Determine if we should use Steel or Alloy Steel suffix based on original material
+                let steel_suffix = if original_material.eq_ignore_ascii_case("Alloy Steel") {
+                    "Alloy Steel"
+                } else {
+                    "Steel"
+                };
+                
                 // Extract grade number from various formats
                 if grade_value.contains("Grade 5") || grade_value.contains("grade 5") {
-                    return "Grade 5 Steel".to_string();
+                    return format!("Grade 5 {}", steel_suffix);
                 } else if grade_value.contains("Grade 8") || grade_value.contains("grade 8") {
-                    return "Grade 8 Steel".to_string();
+                    return format!("Grade 8 {}", steel_suffix);
                 } else if grade_value.contains("Grade 2") || grade_value.contains("grade 2") {
-                    return "Grade 2 Steel".to_string();
+                    return format!("Grade 2 {}", steel_suffix);
                 } else if grade_value.contains("Grade 1") || grade_value.contains("grade 1") {
-                    return "Grade 1 Steel".to_string();
+                    return format!("Grade 1 {}", steel_suffix);
                 } else if grade_value.contains("10.9") {
-                    return "10.9 Steel".to_string();
+                    return format!("10.9 {}", steel_suffix);
                 } else if grade_value.contains("12.9") {
-                    return "12.9 Steel".to_string();
+                    return format!("12.9 {}", steel_suffix);
                 } else if grade_value.contains("8.8") {
-                    return "8.8 Steel".to_string();
+                    return format!("8.8 {}", steel_suffix);
                 }
             }
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -113,11 +113,52 @@ impl NameGenerator {
         screw_abbrevs.insert("Brass".to_string(), "Brass".to_string());
         screw_abbrevs.insert("Aluminum".to_string(), "Al".to_string());
         
-        // Drive style abbreviations
-        screw_abbrevs.insert("Hex".to_string(), "HEX".to_string());
+        // Drive style abbreviations (comprehensive list from McMaster-Carr)
+        screw_abbrevs.insert("4-Flute Spline".to_string(), "4FS".to_string());
+        screw_abbrevs.insert("6-Flute Spline".to_string(), "6FS".to_string());
+        screw_abbrevs.insert("Asymmetrical".to_string(), "ASYM".to_string());
+        screw_abbrevs.insert("Clutch".to_string(), "CLUTCH".to_string());
+        screw_abbrevs.insert("Double Square".to_string(), "DSQUARE".to_string());
+        screw_abbrevs.insert("Drilled Spanner".to_string(), "DSPAN".to_string());
+        screw_abbrevs.insert("External 12-Point".to_string(), "EXT12".to_string());
+        screw_abbrevs.insert("External Hex".to_string(), "EHEX".to_string()); // External hex
+        screw_abbrevs.insert("External Pentagon".to_string(), "EPENT".to_string());
+        screw_abbrevs.insert("External Square".to_string(), "ESQUARE".to_string());
+        screw_abbrevs.insert("Frearson".to_string(), "FREAR".to_string());
+        screw_abbrevs.insert("Hex".to_string(), "HEX".to_string()); // Internal hex (socket)
+        screw_abbrevs.insert("Hex with Pilot Recess".to_string(), "HEXPILOT".to_string());
+        screw_abbrevs.insert("Hi-Torque".to_string(), "HITORQUE".to_string());
+        screw_abbrevs.insert("Microstix".to_string(), "MICRO".to_string());
+        screw_abbrevs.insert("Mortorq®".to_string(), "MORTORQ".to_string());
+        screw_abbrevs.insert("Mortorq® Super".to_string(), "MORTORQS".to_string());
+        screw_abbrevs.insert("No Drive".to_string(), "NODRIVE".to_string());
+        screw_abbrevs.insert("One Way".to_string(), "ONEWAY".to_string());
+        screw_abbrevs.insert("Pentagon".to_string(), "PENT".to_string());
+        screw_abbrevs.insert("Pentalobe".to_string(), "PLOBE".to_string());
         screw_abbrevs.insert("Phillips".to_string(), "PH".to_string());
-        screw_abbrevs.insert("Torx".to_string(), "TX".to_string());
+        screw_abbrevs.insert("Phillips Terminal Screw".to_string(), "PHTERM".to_string());
+        screw_abbrevs.insert("Pozidriv®".to_string(), "PZ".to_string());
+        screw_abbrevs.insert("Pozidriv® Terminal Screw".to_string(), "PZTERM".to_string());
+        screw_abbrevs.insert("RIBE".to_string(), "RIBE".to_string());
         screw_abbrevs.insert("Slotted".to_string(), "SL".to_string());
+        screw_abbrevs.insert("Spring Plunger Driver".to_string(), "SPRING".to_string());
+        screw_abbrevs.insert("Square".to_string(), "SQUARE".to_string());
+        screw_abbrevs.insert("Square/Phillips".to_string(), "SQPH".to_string());
+        screw_abbrevs.insert("Tamper-Resistant Hex".to_string(), "TRHEX".to_string());
+        screw_abbrevs.insert("Tamper-Resistant Pentalobe".to_string(), "TRPLOBE".to_string());
+        screw_abbrevs.insert("Tamper-Resistant Phillips".to_string(), "TRPH".to_string());
+        screw_abbrevs.insert("Tamper-Resistant Square".to_string(), "TRSQUARE".to_string());
+        screw_abbrevs.insert("Tamper-Resistant Torx".to_string(), "TRTX".to_string());
+        screw_abbrevs.insert("Tamper-Resistant Torx Plus".to_string(), "TRTXP".to_string());
+        screw_abbrevs.insert("Torq-Set®".to_string(), "TORQSET".to_string());
+        screw_abbrevs.insert("Torx".to_string(), "TX".to_string());
+        screw_abbrevs.insert("Torx Plus".to_string(), "TXP".to_string());
+        screw_abbrevs.insert("Triangle".to_string(), "TRI".to_string());
+        screw_abbrevs.insert("Tri-Groove".to_string(), "TRIGROOVE".to_string());
+        screw_abbrevs.insert("Tri-Lobe".to_string(), "TRILOBE".to_string());
+        screw_abbrevs.insert("Triple Square".to_string(), "TRISQUARE".to_string());
+        screw_abbrevs.insert("Tri-Wing®".to_string(), "TRIWING".to_string());
+        screw_abbrevs.insert("Wrench Flats".to_string(), "WFLATS".to_string());
         
         // Button Head Screw template
         let bhs_template = NamingTemplate {

--- a/src/client.rs
+++ b/src/client.rs
@@ -916,7 +916,7 @@ impl NameGenerator {
         
         // Locknut template (nylon-insert, prevailing torque, etc.)
         let locknut_template = NamingTemplate {
-            prefix: "LOCKNUT".to_string(),
+            prefix: "LN".to_string(),
             key_specs: vec![
                 "Material".to_string(),
                 "Thread Size".to_string(),
@@ -928,7 +928,7 @@ impl NameGenerator {
         
         // Hex nut template
         let hex_nut_template = NamingTemplate {
-            prefix: "HEXNUT".to_string(),
+            prefix: "HN".to_string(),
             key_specs: vec![
                 "Material".to_string(),
                 "Thread Size".to_string(),
@@ -940,7 +940,7 @@ impl NameGenerator {
         
         // Wing nut template
         let wing_nut_template = NamingTemplate {
-            prefix: "WINGNUT".to_string(),
+            prefix: "WN".to_string(),
             key_specs: vec![
                 "Material".to_string(),
                 "Thread Size".to_string(),
@@ -952,7 +952,7 @@ impl NameGenerator {
         
         // Cap nut template
         let cap_nut_template = NamingTemplate {
-            prefix: "CAPNUT".to_string(),
+            prefix: "CN".to_string(),
             key_specs: vec![
                 "Material".to_string(),
                 "Thread Size".to_string(),
@@ -964,15 +964,307 @@ impl NameGenerator {
         
         // Generic nut template
         let generic_nut_template = NamingTemplate {
-            prefix: "NUT".to_string(),
+            prefix: "N".to_string(),
             key_specs: vec![
                 "Material".to_string(),
                 "Thread Size".to_string(),
                 "Finish".to_string(),
             ],
-            spec_abbreviations: nut_abbrevs,
+            spec_abbreviations: nut_abbrevs.clone(),
         };
         self.category_templates.insert("generic_nut".to_string(), generic_nut_template);
+        
+        // Comprehensive nut type templates
+        
+        // Adhesive Mount Nut
+        let adhesive_mount_nut_template = NamingTemplate {
+            prefix: "AMN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("adhesive_mount_nut".to_string(), adhesive_mount_nut_template);
+        
+        // Clip On Nut
+        let clip_on_nut_template = NamingTemplate {
+            prefix: "CON".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("clip_on_nut".to_string(), clip_on_nut_template);
+        
+        // Coupling Nut
+        let coupling_nut_template = NamingTemplate {
+            prefix: "COUP".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("coupling_nut".to_string(), coupling_nut_template);
+        
+        // Dowel Nut
+        let dowel_nut_template = NamingTemplate {
+            prefix: "DN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("dowel_nut".to_string(), dowel_nut_template);
+        
+        // Externally Threaded Nut
+        let ext_threaded_nut_template = NamingTemplate {
+            prefix: "ETN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("externally_threaded_nut".to_string(), ext_threaded_nut_template);
+        
+        // Flange Nut
+        let flange_nut_template = NamingTemplate {
+            prefix: "FN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("flange_nut".to_string(), flange_nut_template);
+        
+        // Panel Nut
+        let panel_nut_template = NamingTemplate {
+            prefix: "PN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("panel_nut".to_string(), panel_nut_template);
+        
+        // Press Fit Nut
+        let press_fit_nut_template = NamingTemplate {
+            prefix: "PFN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("press_fit_nut".to_string(), press_fit_nut_template);
+        
+        // Push Button Nut
+        let push_button_nut_template = NamingTemplate {
+            prefix: "PBN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("push_button_nut".to_string(), push_button_nut_template);
+        
+        // Push Nut
+        let push_nut_template = NamingTemplate {
+            prefix: "PUSHN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("push_nut".to_string(), push_nut_template);
+        
+        // Rivet Mount Nut
+        let rivet_mount_nut_template = NamingTemplate {
+            prefix: "RMN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("rivet_mount_nut".to_string(), rivet_mount_nut_template);
+        
+        // Rivet Nut
+        let rivet_nut_template = NamingTemplate {
+            prefix: "RN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("rivet_nut".to_string(), rivet_nut_template);
+        
+        // Round Nut
+        let round_nut_template = NamingTemplate {
+            prefix: "ROUNDN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("round_nut".to_string(), round_nut_template);
+        
+        // Screw Mount Nut
+        let screw_mount_nut_template = NamingTemplate {
+            prefix: "SMN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("screw_mount_nut".to_string(), screw_mount_nut_template);
+        
+        // Snap In Nut
+        let snap_in_nut_template = NamingTemplate {
+            prefix: "SIN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("snap_in_nut".to_string(), snap_in_nut_template);
+        
+        // Socket Nut
+        let socket_nut_template = NamingTemplate {
+            prefix: "SN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("socket_nut".to_string(), socket_nut_template);
+        
+        // Speed Nut
+        let speed_nut_template = NamingTemplate {
+            prefix: "SPEEDN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("speed_nut".to_string(), speed_nut_template);
+        
+        // Square Nut
+        let square_nut_template = NamingTemplate {
+            prefix: "SQN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("square_nut".to_string(), square_nut_template);
+        
+        // Tamper Resistant Nut
+        let tamper_resistant_nut_template = NamingTemplate {
+            prefix: "TRN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("tamper_resistant_nut".to_string(), tamper_resistant_nut_template);
+        
+        // Threadless Nut
+        let threadless_nut_template = NamingTemplate {
+            prefix: "TLN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("threadless_nut".to_string(), threadless_nut_template);
+        
+        // Thumb Nut
+        let thumb_nut_template = NamingTemplate {
+            prefix: "THUMBN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("thumb_nut".to_string(), thumb_nut_template);
+        
+        // Tube End Nut
+        let tube_end_nut_template = NamingTemplate {
+            prefix: "TEN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("tube_end_nut".to_string(), tube_end_nut_template);
+        
+        // Twist Close Nut
+        let twist_close_nut_template = NamingTemplate {
+            prefix: "TCN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("twist_close_nut".to_string(), twist_close_nut_template);
+        
+        // Weld Nut
+        let weld_nut_template = NamingTemplate {
+            prefix: "WELD".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("weld_nut".to_string(), weld_nut_template);
+        
+        // With Pilot Hole Nut
+        let with_pilot_hole_nut_template = NamingTemplate {
+            prefix: "WPHN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("with_pilot_hole_nut".to_string(), with_pilot_hole_nut_template);
+        
+        // Locking nut specific types (these will override the generic locknut when detected)
+        
+        // Cotter Pin Locknut
+        let cotter_pin_locknut_template = NamingTemplate {
+            prefix: "CPLN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("cotter_pin_locknut".to_string(), cotter_pin_locknut_template);
+        
+        // Distorted Thread Locknut
+        let distorted_thread_locknut_template = NamingTemplate {
+            prefix: "DTLN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("distorted_thread_locknut".to_string(), distorted_thread_locknut_template);
+        
+        // Flex-Top Locknut
+        let flex_top_locknut_template = NamingTemplate {
+            prefix: "FTLN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("flex_top_locknut".to_string(), flex_top_locknut_template);
+        
+        // Lock Washer Locknut
+        let lock_washer_locknut_template = NamingTemplate {
+            prefix: "LWLN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("lock_washer_locknut".to_string(), lock_washer_locknut_template);
+        
+        // Nylon Insert Locknut (keep existing LN for most common type)
+        let nylon_insert_locknut_template = NamingTemplate {
+            prefix: "LN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("nylon_insert_locknut".to_string(), nylon_insert_locknut_template);
+        
+        // Serrations Locknut
+        let serrations_locknut_template = NamingTemplate {
+            prefix: "SRLN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("serrations_locknut".to_string(), serrations_locknut_template);
+        
+        // Spring-Stop Locknut
+        let spring_stop_locknut_template = NamingTemplate {
+            prefix: "SSLN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("spring_stop_locknut".to_string(), spring_stop_locknut_template);
+        
+        // Steel Insert Locknut
+        let steel_insert_locknut_template = NamingTemplate {
+            prefix: "SILN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("steel_insert_locknut".to_string(), steel_insert_locknut_template);
+        
+        // Thread Forming Locknut
+        let thread_forming_locknut_template = NamingTemplate {
+            prefix: "TFLN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("thread_forming_locknut".to_string(), thread_forming_locknut_template);
+        
+        // Threadlocker Locknut
+        let threadlocker_locknut_template = NamingTemplate {
+            prefix: "TLLN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("threadlocker_locknut".to_string(), threadlocker_locknut_template);
+        
+        // Two-Piece Clamp Locknut
+        let two_piece_clamp_locknut_template = NamingTemplate {
+            prefix: "2PCLN".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Finish".to_string()],
+            spec_abbreviations: nut_abbrevs.clone(),
+        };
+        self.category_templates.insert("two_piece_clamp_locknut".to_string(), two_piece_clamp_locknut_template);
     }
 
     pub fn generate_name(&self, product: &ProductDetail) -> String {
@@ -1139,12 +1431,88 @@ impl NameGenerator {
                 "flat_washer".to_string() // Default to flat washer
             }
         } else if category_lower.contains("nuts") || category_lower.contains("nut") || family_lower.contains("nut") {
-            // Determine specific nut type
-            if family_lower.contains("locknut") || family_lower.contains("lock nut") || 
-               family_lower.contains("nylon-insert") || family_lower.contains("prevailing torque") {
+            // Determine specific nut type (more specific types first)
+            
+            // Locking nut sub-types (most specific first)
+            if family_lower.contains("cotter pin") && (family_lower.contains("locknut") || family_lower.contains("lock nut")) {
+                "cotter_pin_locknut".to_string()
+            } else if family_lower.contains("distorted thread") && (family_lower.contains("locknut") || family_lower.contains("lock nut")) {
+                "distorted_thread_locknut".to_string()
+            } else if family_lower.contains("flex-top") && (family_lower.contains("locknut") || family_lower.contains("lock nut")) {
+                "flex_top_locknut".to_string()
+            } else if family_lower.contains("lock washer") && (family_lower.contains("locknut") || family_lower.contains("lock nut")) {
+                "lock_washer_locknut".to_string()
+            } else if family_lower.contains("nylon insert") || family_lower.contains("nylon-insert") {
+                "nylon_insert_locknut".to_string()
+            } else if family_lower.contains("serrations") && (family_lower.contains("locknut") || family_lower.contains("lock nut")) {
+                "serrations_locknut".to_string()
+            } else if family_lower.contains("spring-stop") && (family_lower.contains("locknut") || family_lower.contains("lock nut")) {
+                "spring_stop_locknut".to_string()
+            } else if family_lower.contains("steel insert") && (family_lower.contains("locknut") || family_lower.contains("lock nut")) {
+                "steel_insert_locknut".to_string()
+            } else if family_lower.contains("thread forming") && (family_lower.contains("locknut") || family_lower.contains("lock nut")) {
+                "thread_forming_locknut".to_string()
+            } else if family_lower.contains("threadlocker") && (family_lower.contains("locknut") || family_lower.contains("lock nut")) {
+                "threadlocker_locknut".to_string()
+            } else if family_lower.contains("two-piece clamp") && (family_lower.contains("locknut") || family_lower.contains("lock nut")) {
+                "two_piece_clamp_locknut".to_string()
+            } else if family_lower.contains("locknut") || family_lower.contains("lock nut") || 
+                     family_lower.contains("prevailing torque") {
                 "locknut".to_string()
+            
+            // Other nut types
+            } else if family_lower.contains("adhesive mount") {
+                "adhesive_mount_nut".to_string()
+            } else if family_lower.contains("clip on") || family_lower.contains("clip-on") {
+                "clip_on_nut".to_string()
+            } else if family_lower.contains("coupling") {
+                "coupling_nut".to_string()
+            } else if family_lower.contains("dowel") {
+                "dowel_nut".to_string()
+            } else if family_lower.contains("externally threaded") {
+                "externally_threaded_nut".to_string()
+            } else if family_lower.contains("flange") {
+                "flange_nut".to_string()
             } else if family_lower.contains("hex nut") || family_lower.contains("hexnut") {
                 "hex_nut".to_string()
+            } else if family_lower.contains("panel") {
+                "panel_nut".to_string()
+            } else if family_lower.contains("press fit") || family_lower.contains("press-fit") {
+                "press_fit_nut".to_string()
+            } else if family_lower.contains("push button") {
+                "push_button_nut".to_string()
+            } else if family_lower.contains("push nut") {
+                "push_nut".to_string()
+            } else if family_lower.contains("rivet mount") {
+                "rivet_mount_nut".to_string()
+            } else if family_lower.contains("rivet nut") {
+                "rivet_nut".to_string()
+            } else if family_lower.contains("round nut") {
+                "round_nut".to_string()
+            } else if family_lower.contains("screw mount") {
+                "screw_mount_nut".to_string()
+            } else if family_lower.contains("snap in") || family_lower.contains("snap-in") {
+                "snap_in_nut".to_string()
+            } else if family_lower.contains("socket nut") {
+                "socket_nut".to_string()
+            } else if family_lower.contains("speed") {
+                "speed_nut".to_string()
+            } else if family_lower.contains("square") {
+                "square_nut".to_string()
+            } else if family_lower.contains("tamper resistant") || family_lower.contains("tamper-resistant") {
+                "tamper_resistant_nut".to_string()
+            } else if family_lower.contains("threadless") {
+                "threadless_nut".to_string()
+            } else if family_lower.contains("thumb") {
+                "thumb_nut".to_string()
+            } else if family_lower.contains("tube end") {
+                "tube_end_nut".to_string()
+            } else if family_lower.contains("twist close") || family_lower.contains("twist-close") {
+                "twist_close_nut".to_string()
+            } else if family_lower.contains("weld") {
+                "weld_nut".to_string()
+            } else if family_lower.contains("with pilot hole") {
+                "with_pilot_hole_nut".to_string()
             } else if family_lower.contains("wing nut") || family_lower.contains("wingnut") {
                 "wing_nut".to_string()
             } else if family_lower.contains("cap nut") || family_lower.contains("capnut") {

--- a/src/client.rs
+++ b/src/client.rs
@@ -109,7 +109,16 @@ impl NameGenerator {
         screw_abbrevs.insert("316 Stainless Steel".to_string(), "SS316".to_string());
         screw_abbrevs.insert("18-8 Stainless Steel".to_string(), "SS188".to_string());
         screw_abbrevs.insert("Stainless Steel".to_string(), "SS".to_string());
-        screw_abbrevs.insert("Steel".to_string(), "Steel".to_string());
+        screw_abbrevs.insert("Steel".to_string(), "S".to_string());
+        
+        // Steel grade abbreviations
+        screw_abbrevs.insert("Grade 1 Steel".to_string(), "SG1".to_string());
+        screw_abbrevs.insert("Grade 2 Steel".to_string(), "SG2".to_string());
+        screw_abbrevs.insert("Grade 5 Steel".to_string(), "SG5".to_string());
+        screw_abbrevs.insert("Grade 8 Steel".to_string(), "SG8".to_string());
+        screw_abbrevs.insert("8.8 Steel".to_string(), "S8.8".to_string());
+        screw_abbrevs.insert("10.9 Steel".to_string(), "S10.9".to_string());
+        screw_abbrevs.insert("12.9 Steel".to_string(), "S12.9".to_string());
         screw_abbrevs.insert("Brass".to_string(), "Brass".to_string());
         screw_abbrevs.insert("Aluminum".to_string(), "Al".to_string());
         
@@ -650,7 +659,16 @@ impl NameGenerator {
         washer_abbrevs.insert("316 Stainless Steel".to_string(), "SS316".to_string());
         washer_abbrevs.insert("18-8 Stainless Steel".to_string(), "SS188".to_string());
         washer_abbrevs.insert("Stainless Steel".to_string(), "SS".to_string());
-        washer_abbrevs.insert("Steel".to_string(), "Steel".to_string());
+        washer_abbrevs.insert("Steel".to_string(), "S".to_string());
+        
+        // Steel grade abbreviations for washers
+        washer_abbrevs.insert("Grade 1 Steel".to_string(), "SG1".to_string());
+        washer_abbrevs.insert("Grade 2 Steel".to_string(), "SG2".to_string());
+        washer_abbrevs.insert("Grade 5 Steel".to_string(), "SG5".to_string());
+        washer_abbrevs.insert("Grade 8 Steel".to_string(), "SG8".to_string());
+        washer_abbrevs.insert("8.8 Steel".to_string(), "S8.8".to_string());
+        washer_abbrevs.insert("10.9 Steel".to_string(), "S10.9".to_string());
+        washer_abbrevs.insert("12.9 Steel".to_string(), "S12.9".to_string());
         washer_abbrevs.insert("Brass".to_string(), "Brass".to_string());
         washer_abbrevs.insert("Aluminum".to_string(), "Al".to_string());
         washer_abbrevs.insert("Copper".to_string(), "Cu".to_string());
@@ -865,7 +883,16 @@ impl NameGenerator {
         nut_abbrevs.insert("316 Stainless Steel".to_string(), "SS316".to_string());
         nut_abbrevs.insert("18-8 Stainless Steel".to_string(), "SS188".to_string());
         nut_abbrevs.insert("Stainless Steel".to_string(), "SS".to_string());
-        nut_abbrevs.insert("Steel".to_string(), "Steel".to_string());
+        nut_abbrevs.insert("Steel".to_string(), "S".to_string());
+        
+        // Steel grade abbreviations for nuts
+        nut_abbrevs.insert("Grade 1 Steel".to_string(), "SG1".to_string());
+        nut_abbrevs.insert("Grade 2 Steel".to_string(), "SG2".to_string());
+        nut_abbrevs.insert("Grade 5 Steel".to_string(), "SG5".to_string());
+        nut_abbrevs.insert("Grade 8 Steel".to_string(), "SG8".to_string());
+        nut_abbrevs.insert("8.8 Steel".to_string(), "S8.8".to_string());
+        nut_abbrevs.insert("10.9 Steel".to_string(), "S10.9".to_string());
+        nut_abbrevs.insert("12.9 Steel".to_string(), "S12.9".to_string());
         nut_abbrevs.insert("Brass".to_string(), "Brass".to_string());
         nut_abbrevs.insert("Aluminum".to_string(), "Al".to_string());
         
@@ -1144,10 +1171,17 @@ impl NameGenerator {
                 if spec_name.eq_ignore_ascii_case("Material") {
                     let (material, finish) = self.parse_material_and_finish(&value);
                     
+                    // Check for steel grade to make steel more descriptive
+                    let final_material = if material.eq_ignore_ascii_case("Steel") {
+                        self.get_steel_grade_material(product, &material)
+                    } else {
+                        material
+                    };
+                    
                     // Add material abbreviation
-                    let material_abbrev = template.spec_abbreviations.get(&material)
+                    let material_abbrev = template.spec_abbreviations.get(&final_material)
                         .cloned()
-                        .unwrap_or_else(|| self.abbreviate_value(&material));
+                        .unwrap_or_else(|| self.abbreviate_value(&final_material));
                     if !material_abbrev.is_empty() {
                         name_parts.push(material_abbrev);
                     }
@@ -1280,6 +1314,37 @@ impl NameGenerator {
             // Return as-is for already decimal values
             value.to_string()
         }
+    }
+
+    fn get_steel_grade_material(&self, product: &ProductDetail, original_material: &str) -> String {
+        // Look for "Fastener Strength Grade/Class" specification to get more descriptive steel naming
+        if let Some(grade_spec) = product.specifications.iter()
+            .find(|s| s.attribute.eq_ignore_ascii_case("Fastener Strength Grade/Class") || 
+                     s.attribute.contains("Grade") || 
+                     s.attribute.contains("Strength")) 
+        {
+            if let Some(grade_value) = grade_spec.values.first() {
+                // Extract grade number from various formats
+                if grade_value.contains("Grade 5") || grade_value.contains("grade 5") {
+                    return "Grade 5 Steel".to_string();
+                } else if grade_value.contains("Grade 8") || grade_value.contains("grade 8") {
+                    return "Grade 8 Steel".to_string();
+                } else if grade_value.contains("Grade 2") || grade_value.contains("grade 2") {
+                    return "Grade 2 Steel".to_string();
+                } else if grade_value.contains("Grade 1") || grade_value.contains("grade 1") {
+                    return "Grade 1 Steel".to_string();
+                } else if grade_value.contains("10.9") {
+                    return "10.9 Steel".to_string();
+                } else if grade_value.contains("12.9") {
+                    return "12.9 Steel".to_string();
+                } else if grade_value.contains("8.8") {
+                    return "8.8 Steel".to_string();
+                }
+            }
+        }
+        
+        // Fallback to original material if no grade found
+        original_material.to_string()
     }
 
     fn extract_thread_with_pitch(&self, product: &ProductDetail, thread_size: &str) -> String {

--- a/src/client.rs
+++ b/src/client.rs
@@ -119,9 +119,9 @@ impl NameGenerator {
         screw_abbrevs.insert("Torx".to_string(), "TX".to_string());
         screw_abbrevs.insert("Slotted".to_string(), "SL".to_string());
         
-        // Button Head Cap Screw template
-        let bhcs_template = NamingTemplate {
-            prefix: "BHCS".to_string(),
+        // Button Head Screw template
+        let bhs_template = NamingTemplate {
+            prefix: "BHS".to_string(),
             key_specs: vec![
                 "Material".to_string(),
                 "Thread Size".to_string(), 
@@ -131,11 +131,11 @@ impl NameGenerator {
             spec_abbreviations: screw_abbrevs.clone(),
         };
         
-        self.category_templates.insert("button_head_screw".to_string(), bhcs_template);
+        self.category_templates.insert("button_head_screw".to_string(), bhs_template);
         
-        // Flat Head Cap Screw template
-        let fhcs_template = NamingTemplate {
-            prefix: "FHCS".to_string(),
+        // Flat Head Screw template
+        let fhs_template = NamingTemplate {
+            prefix: "FHS".to_string(),
             key_specs: vec![
                 "Material".to_string(),
                 "Thread Size".to_string(), 
@@ -144,11 +144,11 @@ impl NameGenerator {
             ],
             spec_abbreviations: screw_abbrevs.clone(),
         };
-        self.category_templates.insert("flat_head_screw".to_string(), fhcs_template);
+        self.category_templates.insert("flat_head_screw".to_string(), fhs_template);
         
-        // Socket Head Cap Screw template
-        let shcs_template = NamingTemplate {
-            prefix: "SHCS".to_string(),
+        // Socket Head Screw template
+        let shs_template = NamingTemplate {
+            prefix: "SHS".to_string(),
             key_specs: vec![
                 "Material".to_string(),
                 "Thread Size".to_string(), 
@@ -157,7 +157,20 @@ impl NameGenerator {
             ],
             spec_abbreviations: screw_abbrevs.clone(),
         };
-        self.category_templates.insert("socket_head_screw".to_string(), shcs_template);
+        self.category_templates.insert("socket_head_screw".to_string(), shs_template);
+        
+        // Pan Head Screw template
+        let phs_template = NamingTemplate {
+            prefix: "PHS".to_string(),
+            key_specs: vec![
+                "Material".to_string(),
+                "Thread Size".to_string(), 
+                "Length".to_string(),
+                "Drive Style".to_string(),
+            ],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("pan_head_screw".to_string(), phs_template);
         
         // Generic screw template
         let generic_screw_template = NamingTemplate {
@@ -281,6 +294,8 @@ impl NameGenerator {
             "flat_head_screw".to_string()
         } else if family_lower.contains("socket head") && family_lower.contains("screw") {
             "socket_head_screw".to_string()
+        } else if family_lower.contains("pan head") && family_lower.contains("screw") {
+            "pan_head_screw".to_string()
         } else if category_lower.contains("screw") || family_lower.contains("screw") {
             "generic_screw".to_string()
         } else if category_lower.contains("washer") || family_lower.contains("washer") {

--- a/src/client.rs
+++ b/src/client.rs
@@ -187,6 +187,59 @@ impl NameGenerator {
         };
         self.category_templates.insert("flat_head_screw".to_string(), fhs_template);
         
+        // Flat Head subcategory templates  
+        // Narrow Flat Head Screw
+        let narrow_fhs_template = NamingTemplate {
+            prefix: "NFHS".to_string(),
+            key_specs: vec![
+                "Material".to_string(),
+                "Thread Size".to_string(), 
+                "Length".to_string(),
+                "Drive Style".to_string(),
+            ],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("narrow_flat_head_screw".to_string(), narrow_fhs_template);
+        
+        // Standard Flat Head Screw
+        let standard_fhs_template = NamingTemplate {
+            prefix: "SFHS".to_string(),
+            key_specs: vec![
+                "Material".to_string(),
+                "Thread Size".to_string(), 
+                "Length".to_string(),
+                "Drive Style".to_string(),
+            ],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("standard_flat_head_screw".to_string(), standard_fhs_template);
+        
+        // Undercut Flat Head Screw
+        let undercut_fhs_template = NamingTemplate {
+            prefix: "UFHS".to_string(),
+            key_specs: vec![
+                "Material".to_string(),
+                "Thread Size".to_string(), 
+                "Length".to_string(),
+                "Drive Style".to_string(),
+            ],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("undercut_flat_head_screw".to_string(), undercut_fhs_template);
+        
+        // Wide Flat Head Screw
+        let wide_fhs_template = NamingTemplate {
+            prefix: "WFHS".to_string(),
+            key_specs: vec![
+                "Material".to_string(),
+                "Thread Size".to_string(), 
+                "Length".to_string(),
+                "Drive Style".to_string(),
+            ],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("wide_flat_head_screw".to_string(), wide_fhs_template);
+        
         // Socket Head Screw template
         let shs_template = NamingTemplate {
             prefix: "SHS".to_string(),
@@ -199,6 +252,59 @@ impl NameGenerator {
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("socket_head_screw".to_string(), shs_template);
+        
+        // Socket Head subcategory templates
+        // High Socket Head Screw
+        let high_shs_template = NamingTemplate {
+            prefix: "HSHS".to_string(),
+            key_specs: vec![
+                "Material".to_string(),
+                "Thread Size".to_string(), 
+                "Length".to_string(),
+                "Drive Style".to_string(),
+            ],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("high_socket_head_screw".to_string(), high_shs_template);
+        
+        // Low Socket Head Screw  
+        let low_shs_template = NamingTemplate {
+            prefix: "LSHS".to_string(),
+            key_specs: vec![
+                "Material".to_string(),
+                "Thread Size".to_string(), 
+                "Length".to_string(),
+                "Drive Style".to_string(),
+            ],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("low_socket_head_screw".to_string(), low_shs_template);
+        
+        // Ultra Low Socket Head Screw
+        let ultra_low_shs_template = NamingTemplate {
+            prefix: "ULSHS".to_string(),
+            key_specs: vec![
+                "Material".to_string(),
+                "Thread Size".to_string(), 
+                "Length".to_string(),
+                "Drive Style".to_string(),
+            ],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("ultra_low_socket_head_screw".to_string(), ultra_low_shs_template);
+        
+        // Standard Socket Head Screw
+        let standard_shs_template = NamingTemplate {
+            prefix: "SSHS".to_string(),
+            key_specs: vec![
+                "Material".to_string(),
+                "Thread Size".to_string(), 
+                "Length".to_string(),
+                "Drive Style".to_string(),
+            ],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("standard_socket_head_screw".to_string(), standard_shs_template);
         
         // Pan Head Screw template
         let phs_template = NamingTemplate {
@@ -224,6 +330,290 @@ impl NameGenerator {
             spec_abbreviations: screw_abbrevs.clone(),
         };
         self.category_templates.insert("generic_screw".to_string(), generic_screw_template);
+        
+        // All head type templates
+        // 12-Point Head Screw
+        let twelve_point_template = NamingTemplate {
+            prefix: "12PHS".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("12_point_head_screw".to_string(), twelve_point_template);
+        
+        // Domed Head Screw
+        let domed_template = NamingTemplate {
+            prefix: "DHS".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("domed_head_screw".to_string(), domed_template);
+        
+        // Eye Screw
+        let eye_template = NamingTemplate {
+            prefix: "EYE".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("eye_screw".to_string(), eye_template);
+        
+        // Headless Screw (Set Screw)
+        let headless_template = NamingTemplate {
+            prefix: "HEADLESS".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("headless_screw".to_string(), headless_template);
+        
+        // Hex Head Screw
+        let hex_head_template = NamingTemplate {
+            prefix: "HHS".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("hex_head_screw".to_string(), hex_head_template);
+        
+        // Hook Screw
+        let hook_template = NamingTemplate {
+            prefix: "HOOK".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("hook_screw".to_string(), hook_template);
+        
+        // Knob Screw
+        let knob_template = NamingTemplate {
+            prefix: "KNOB".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("knob_screw".to_string(), knob_template);
+        
+        // L-Handle Screw
+        let l_handle_template = NamingTemplate {
+            prefix: "LHS".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("l_handle_screw".to_string(), l_handle_template);
+        
+        // Oval Head Screw
+        let oval_template = NamingTemplate {
+            prefix: "OHS".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("oval_head_screw".to_string(), oval_template);
+        
+        // Oval Head subcategory templates
+        // Standard Oval Head Screw
+        let standard_oval_template = NamingTemplate {
+            prefix: "SOHS".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("standard_oval_head_screw".to_string(), standard_oval_template);
+        
+        // Undercut Oval Head Screw
+        let undercut_oval_template = NamingTemplate {
+            prefix: "UOHS".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("undercut_oval_head_screw".to_string(), undercut_oval_template);
+        
+        // Pentagon Head Screw
+        let pentagon_head_template = NamingTemplate {
+            prefix: "PENTHS".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("pentagon_head_screw".to_string(), pentagon_head_template);
+        
+        // Ring Screw
+        let ring_template = NamingTemplate {
+            prefix: "RING".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("ring_screw".to_string(), ring_template);
+        
+        // Rounded Head Screw
+        let rounded_template = NamingTemplate {
+            prefix: "RHS".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("rounded_head_screw".to_string(), rounded_template);
+        
+        // Square Head Screw
+        let square_head_template = NamingTemplate {
+            prefix: "SQHS".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("square_head_screw".to_string(), square_head_template);
+        
+        // Tee Screw
+        let tee_template = NamingTemplate {
+            prefix: "TEE".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("tee_screw".to_string(), tee_template);
+        
+        // T-Handle Screw
+        let t_handle_template = NamingTemplate {
+            prefix: "THS".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("t_handle_screw".to_string(), t_handle_template);
+        
+        // Threaded Screw
+        let threaded_template = NamingTemplate {
+            prefix: "THREADED".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("threaded_screw".to_string(), threaded_template);
+        
+        // Thumb Screw
+        let thumb_template = NamingTemplate {
+            prefix: "THUMB".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("thumb_screw".to_string(), thumb_template);
+        
+        // Thumb Screw subcategory templates
+        // Four Arm Thumb Screw
+        let four_arm_thumb_template = NamingTemplate {
+            prefix: "4ARM".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("four_arm_thumb_screw".to_string(), four_arm_thumb_template);
+        
+        // Hex Thumb Screw
+        let hex_thumb_template = NamingTemplate {
+            prefix: "HEXTHUMB".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("hex_thumb_screw".to_string(), hex_thumb_template);
+        
+        // Multilobe Thumb Screw
+        let multilobe_thumb_template = NamingTemplate {
+            prefix: "MULTILOBE".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("multilobe_thumb_screw".to_string(), multilobe_thumb_template);
+        
+        // Rectangle Thumb Screw
+        let rectangle_thumb_template = NamingTemplate {
+            prefix: "RECTTHUMB".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("rectangle_thumb_screw".to_string(), rectangle_thumb_template);
+        
+        // Round Thumb Screw
+        let round_thumb_template = NamingTemplate {
+            prefix: "ROUNDTHUMB".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("round_thumb_screw".to_string(), round_thumb_template);
+        
+        // Spade Thumb Screw
+        let spade_thumb_template = NamingTemplate {
+            prefix: "SPADE".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("spade_thumb_screw".to_string(), spade_thumb_template);
+        
+        // Two Arm Thumb Screw
+        let two_arm_thumb_template = NamingTemplate {
+            prefix: "2ARM".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("two_arm_thumb_screw".to_string(), two_arm_thumb_template);
+        
+        // Wing Thumb Screw
+        let wing_thumb_template = NamingTemplate {
+            prefix: "WINGTHUMB".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("wing_thumb_screw".to_string(), wing_thumb_template);
+        
+        // T-Slot Screw
+        let t_slot_template = NamingTemplate {
+            prefix: "TSLOT".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("t_slot_screw".to_string(), t_slot_template);
+        
+        // Rounded head subcategory templates
+        // Binding Head Screw
+        let binding_head_template = NamingTemplate {
+            prefix: "BINDING".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("binding_head_screw".to_string(), binding_head_template);
+        
+        // Carriage Head Screw
+        let carriage_head_template = NamingTemplate {
+            prefix: "CARRIAGE".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("carriage_head_screw".to_string(), carriage_head_template);
+        
+        // Cheese Head Screw
+        let cheese_head_template = NamingTemplate {
+            prefix: "CHEESE".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("cheese_head_screw".to_string(), cheese_head_template);
+        
+        // Fillister Head Screw
+        let fillister_head_template = NamingTemplate {
+            prefix: "FILLISTER".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("fillister_head_screw".to_string(), fillister_head_template);
+        
+        // Pancake Head Screw
+        let pancake_head_template = NamingTemplate {
+            prefix: "PANCAKE".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("pancake_head_screw".to_string(), pancake_head_template);
+        
+        // Round Head Screw
+        let round_head_template = NamingTemplate {
+            prefix: "ROUND".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("round_head_screw".to_string(), round_head_template);
+        
+        // Truss Head Screw
+        let truss_head_template = NamingTemplate {
+            prefix: "TRUSS".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Drive Style".to_string()],
+            spec_abbreviations: screw_abbrevs.clone(),
+        };
+        self.category_templates.insert("truss_head_screw".to_string(), truss_head_template);
         
         // Washer template
         let mut washer_abbrevs = HashMap::new();
@@ -328,15 +718,101 @@ impl NameGenerator {
         let category_lower = product.product_category.to_lowercase();
         let _detail_lower = product.detail_description.to_lowercase();
         
-        // Check for specific screw types
+        // Check for specific screw head types (order matters - more specific first)
         if family_lower.contains("button head") && family_lower.contains("screw") {
             "button_head_screw".to_string()
-        } else if family_lower.contains("flat head") && family_lower.contains("screw") {
-            "flat_head_screw".to_string()
+        } else if family_lower.contains("high socket head") && family_lower.contains("screw") {
+            "high_socket_head_screw".to_string()
+        } else if family_lower.contains("low socket head") && family_lower.contains("screw") {
+            "low_socket_head_screw".to_string()
+        } else if family_lower.contains("ultra low socket head") && family_lower.contains("screw") {
+            "ultra_low_socket_head_screw".to_string()
+        } else if family_lower.contains("standard socket head") && family_lower.contains("screw") {
+            "standard_socket_head_screw".to_string()
         } else if family_lower.contains("socket head") && family_lower.contains("screw") {
             "socket_head_screw".to_string()
+        } else if family_lower.contains("narrow flat head") && family_lower.contains("screw") {
+            "narrow_flat_head_screw".to_string()
+        } else if family_lower.contains("standard flat head") && family_lower.contains("screw") {
+            "standard_flat_head_screw".to_string()
+        } else if family_lower.contains("undercut flat head") && family_lower.contains("screw") {
+            "undercut_flat_head_screw".to_string()
+        } else if family_lower.contains("wide flat head") && family_lower.contains("screw") {
+            "wide_flat_head_screw".to_string()
+        } else if family_lower.contains("flat head") && family_lower.contains("screw") {
+            "flat_head_screw".to_string()
         } else if family_lower.contains("pan head") && family_lower.contains("screw") {
             "pan_head_screw".to_string()
+        } else if family_lower.contains("hex head") && family_lower.contains("screw") {
+            "hex_head_screw".to_string()
+        } else if family_lower.contains("standard oval head") && family_lower.contains("screw") {
+            "standard_oval_head_screw".to_string()
+        } else if family_lower.contains("undercut oval head") && family_lower.contains("screw") {
+            "undercut_oval_head_screw".to_string()
+        } else if family_lower.contains("oval head") && family_lower.contains("screw") {
+            "oval_head_screw".to_string()
+        } else if family_lower.contains("square head") && family_lower.contains("screw") {
+            "square_head_screw".to_string()
+        } else if family_lower.contains("binding head") && family_lower.contains("screw") {
+            "binding_head_screw".to_string()
+        } else if family_lower.contains("carriage head") && family_lower.contains("screw") {
+            "carriage_head_screw".to_string()
+        } else if family_lower.contains("cheese head") && family_lower.contains("screw") {
+            "cheese_head_screw".to_string()
+        } else if family_lower.contains("fillister head") && family_lower.contains("screw") {
+            "fillister_head_screw".to_string()
+        } else if family_lower.contains("pancake head") && family_lower.contains("screw") {
+            "pancake_head_screw".to_string()
+        } else if family_lower.contains("round head") && family_lower.contains("screw") {
+            "round_head_screw".to_string()
+        } else if family_lower.contains("truss head") && family_lower.contains("screw") {
+            "truss_head_screw".to_string()
+        } else if family_lower.contains("rounded head") && family_lower.contains("screw") {  // More specific than just "rounded"
+            "rounded_head_screw".to_string()
+        } else if family_lower.contains("12-point") && family_lower.contains("screw") {
+            "12_point_head_screw".to_string()
+        } else if family_lower.contains("t-handle") && family_lower.contains("screw") {
+            "t_handle_screw".to_string()
+        } else if family_lower.contains("t-slot") && family_lower.contains("screw") {
+            "t_slot_screw".to_string()
+        } else if family_lower.contains("l-handle") && family_lower.contains("screw") {
+            "l_handle_screw".to_string()
+        } else if family_lower.contains("domed") && family_lower.contains("screw") {
+            "domed_head_screw".to_string()
+        } else if family_lower.contains("headless") && family_lower.contains("screw") {
+            "headless_screw".to_string()
+        } else if family_lower.contains("pentagon") && family_lower.contains("screw") {
+            "pentagon_head_screw".to_string()
+        } else if family_lower.contains("four arm thumb") && family_lower.contains("screw") {
+            "four_arm_thumb_screw".to_string()
+        } else if family_lower.contains("hex thumb") && family_lower.contains("screw") {
+            "hex_thumb_screw".to_string()
+        } else if family_lower.contains("multilobe thumb") && family_lower.contains("screw") {
+            "multilobe_thumb_screw".to_string()
+        } else if family_lower.contains("rectangle thumb") && family_lower.contains("screw") {
+            "rectangle_thumb_screw".to_string()
+        } else if family_lower.contains("round thumb") && family_lower.contains("screw") {
+            "round_thumb_screw".to_string()
+        } else if family_lower.contains("spade thumb") && family_lower.contains("screw") {
+            "spade_thumb_screw".to_string()
+        } else if family_lower.contains("two arm thumb") && family_lower.contains("screw") {
+            "two_arm_thumb_screw".to_string()
+        } else if family_lower.contains("wing thumb") && family_lower.contains("screw") {
+            "wing_thumb_screw".to_string()
+        } else if family_lower.contains("thumb") && family_lower.contains("screw") {
+            "thumb_screw".to_string()
+        } else if family_lower.contains("hook") && family_lower.contains("screw") {
+            "hook_screw".to_string()
+        } else if family_lower.contains("ring") && family_lower.contains("screw") {
+            "ring_screw".to_string()
+        } else if family_lower.contains("eye") && family_lower.contains("screw") {
+            "eye_screw".to_string()
+        } else if family_lower.contains("knob") && family_lower.contains("screw") {
+            "knob_screw".to_string()
+        } else if family_lower.contains("threaded") && family_lower.contains("screw") {
+            "threaded_screw".to_string()
+        } else if family_lower.contains("tee") && family_lower.contains("screw") {
+            "tee_screw".to_string()
         } else if category_lower.contains("screw") || family_lower.contains("screw") {
             "generic_screw".to_string()
         } else if category_lower.contains("washer") || family_lower.contains("washer") {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1295,6 +1295,74 @@ impl NameGenerator {
             spec_abbreviations: nut_abbrevs.clone(),
         };
         self.category_templates.insert("two_piece_clamp_locknut".to_string(), two_piece_clamp_locknut_template);
+        
+        // Threaded Standoff templates
+        let mut standoff_abbrevs = HashMap::new();
+        
+        // Material abbreviations for standoffs
+        standoff_abbrevs.insert("316 Stainless Steel".to_string(), "SS316".to_string());
+        standoff_abbrevs.insert("18-8 Stainless Steel".to_string(), "SS188".to_string());
+        standoff_abbrevs.insert("Stainless Steel".to_string(), "SS".to_string());
+        standoff_abbrevs.insert("Steel".to_string(), "S".to_string());
+        standoff_abbrevs.insert("Alloy Steel".to_string(), "S".to_string());
+        standoff_abbrevs.insert("Brass".to_string(), "Brass".to_string());
+        standoff_abbrevs.insert("Aluminum".to_string(), "Al".to_string());
+        standoff_abbrevs.insert("Nylon".to_string(), "Nylon".to_string());
+        
+        // Steel grade abbreviations for standoffs
+        standoff_abbrevs.insert("Grade 1 Steel".to_string(), "SG1".to_string());
+        standoff_abbrevs.insert("Grade 2 Steel".to_string(), "SG2".to_string());
+        standoff_abbrevs.insert("Grade 5 Steel".to_string(), "SG5".to_string());
+        standoff_abbrevs.insert("Grade 8 Steel".to_string(), "SG8".to_string());
+        standoff_abbrevs.insert("8.8 Steel".to_string(), "S8.8".to_string());
+        standoff_abbrevs.insert("10.9 Steel".to_string(), "S10.9".to_string());
+        standoff_abbrevs.insert("12.9 Steel".to_string(), "S12.9".to_string());
+        standoff_abbrevs.insert("Grade 1 Alloy Steel".to_string(), "SG1".to_string());
+        standoff_abbrevs.insert("Grade 2 Alloy Steel".to_string(), "SG2".to_string());
+        standoff_abbrevs.insert("Grade 5 Alloy Steel".to_string(), "SG5".to_string());
+        standoff_abbrevs.insert("Grade 8 Alloy Steel".to_string(), "SG8".to_string());
+        standoff_abbrevs.insert("8.8 Alloy Steel".to_string(), "S8.8".to_string());
+        standoff_abbrevs.insert("10.9 Alloy Steel".to_string(), "S10.9".to_string());
+        standoff_abbrevs.insert("12.9 Alloy Steel".to_string(), "S12.9".to_string());
+        
+        // Finish abbreviations for standoffs
+        standoff_abbrevs.insert("Zinc Plated".to_string(), "ZP".to_string());
+        standoff_abbrevs.insert("Zinc-Plated".to_string(), "ZP".to_string());
+        standoff_abbrevs.insert("Zinc Yellow-Chromate Plated".to_string(), "ZYC".to_string());
+        standoff_abbrevs.insert("Zinc Yellow Chromate Plated".to_string(), "ZYC".to_string());
+        standoff_abbrevs.insert("Black Oxide".to_string(), "BO".to_string());
+        standoff_abbrevs.insert("Black-Oxide".to_string(), "BO".to_string());
+        standoff_abbrevs.insert("Cadmium Plated".to_string(), "CD".to_string());
+        standoff_abbrevs.insert("Cadmium-Plated".to_string(), "CD".to_string());
+        standoff_abbrevs.insert("Nickel Plated".to_string(), "NI".to_string());
+        standoff_abbrevs.insert("Nickel-Plated".to_string(), "NI".to_string());
+        standoff_abbrevs.insert("Chrome Plated".to_string(), "CR".to_string());
+        standoff_abbrevs.insert("Chrome-Plated".to_string(), "CR".to_string());
+        standoff_abbrevs.insert("Galvanized".to_string(), "GAL".to_string());
+        
+        // Male-Female Threaded Hex Standoff
+        let male_female_hex_standoff_template = NamingTemplate {
+            prefix: "MFSO".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Finish".to_string()],
+            spec_abbreviations: standoff_abbrevs.clone(),
+        };
+        self.category_templates.insert("male_female_hex_standoff".to_string(), male_female_hex_standoff_template);
+        
+        // Female Threaded Hex Standoff
+        let female_hex_standoff_template = NamingTemplate {
+            prefix: "FSO".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Finish".to_string()],
+            spec_abbreviations: standoff_abbrevs.clone(),
+        };
+        self.category_templates.insert("female_hex_standoff".to_string(), female_hex_standoff_template);
+        
+        // Generic Threaded Standoff (fallback)
+        let generic_standoff_template = NamingTemplate {
+            prefix: "SO".to_string(),
+            key_specs: vec!["Material".to_string(), "Thread Size".to_string(), "Length".to_string(), "Finish".to_string()],
+            spec_abbreviations: standoff_abbrevs,
+        };
+        self.category_templates.insert("generic_standoff".to_string(), generic_standoff_template);
     }
 
     pub fn generate_name(&self, product: &ProductDetail) -> String {
@@ -1550,6 +1618,16 @@ impl NameGenerator {
             } else {
                 "generic_nut".to_string()
             }
+        } else if category_lower.contains("standoffs") || category_lower.contains("standoff") || 
+                  family_lower.contains("standoff") || family_lower.contains("spacer") {
+            // Determine specific standoff type
+            if family_lower.contains("male-female") || family_lower.contains("male female") {
+                "male_female_hex_standoff".to_string()
+            } else if family_lower.contains("female") && family_lower.contains("threaded") {
+                "female_hex_standoff".to_string()
+            } else {
+                "generic_standoff".to_string()
+            }
         } else {
             "unknown".to_string()
         }
@@ -1675,7 +1753,7 @@ impl NameGenerator {
     fn convert_length_to_decimal(&self, value: &str) -> String {
         // Convert common fractions to decimals for screw lengths
         if value.contains("\"") {
-            let clean_value = value.replace("\"", "");
+            let clean_value = value.replace("\"", "").replace(" ", "-"); // Convert space format to hyphen format
             match clean_value.as_str() {
                 "1/8" => "0.125".to_string(),
                 "3/16" => "0.1875".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,6 +154,11 @@ enum Commands {
         #[arg(short, long)]
         output: Option<String>,
     },
+    /// Generate human-readable name for product
+    Name {
+        /// Product number
+        product: String,
+    },
 }
 
 async fn load_credentials_from_file(path: &str) -> Result<Credentials> {
@@ -391,6 +396,9 @@ async fn main() -> Result<()> {
         }
         Commands::Datasheet { product, output } => {
             client.download_datasheets(&product, output.as_deref()).await?;
+        }
+        Commands::Name { product } => {
+            client.generate_name(&product).await?;
         }
     }
 


### PR DESCRIPTION
## Summary
Implements a comprehensive part naming system for McMaster-Carr CLI that generates human-readable, abbreviated technical names for all major fastener categories. This massive enhancement transforms part numbers into standardized technical nomenclature suitable for BOMs, CAD systems, and technical documentation.

### New Features Added
- **Complete Part Naming System**: Generate abbreviated technical names for any McMaster-Carr part
- **5 Major Fastener Categories**: Screws, nuts, washers, threaded standoffs, and bearings
- **Smart Material Detection**: Handles steel grades, finishes, and composite materials
- **Dimension Standardization**: Automatic fraction-to-decimal conversion and metric support
- **Comprehensive Abbreviation System**: 300+ material, finish, and drive style abbreviations

### Supported Categories

#### Screws & Bolts (20+ head types)
- Button Head: `BHS-SS316-8x32-0.25-HEX`
- Socket Head: `SHS-Steel-1/4x20-1-HEX` 
- Flat Head: `FHS-SS188-M6x1.0-20-PH`
- Hex Head: `HHS-SG5-1/4x20-1-EHEX`
- Plus 16 additional head types with drive style support

#### Nuts (36+ types with abbreviated prefixes)
- Hex Nut: `HN-S-4x40-ZP`
- Locknut: `LN-SS188-4x40`
- Wing Nut: `WN-Brass-8x32`
- Includes specialized types: flange, socket, speed, tamper-resistant, etc.

#### Washers (19 specific types)
- Flat Washer: `FW-SS316-1/4`
- Split Washer: `SPLW-SS188-8x32`
- Cup Washer: `CW-SS316-1/4`
- Comprehensive support for all washer geometries

#### Threaded Standoffs (3 types)
- Male-Female: `MFSO-SS-4x40-0.5`
- Female: `FSO-Brass-M6x1.0-25`
- Generic: `SO-Al-8x32-0.75`

#### Bearings (8 types) - NEW!
- Flanged Sleeve: `FSB-MDSNYL-0.25-0.375-0.25`
- Plain Sleeve: `SB-BR841-0.375-0.5-0.5`
- Ball Bearing: `BB-SS-6-19`
- Plus linear, needle, roller, and generic types

### Advanced Features
- **Steel Grade Detection**: Automatically detects and abbreviates Grade 5 (SG5), Grade 8 (SG8), Class 8.8 (S8.8), etc.
- **Smart Finish Handling**: Extracts finishes from materials, omits meaningless finishes (passivated)
- **Filler Material Support**: Combines materials like "MDS-Filled Nylon" automatically
- **Thread Standardization**: Uses x-separator format (8x32, M6x1.0) across all fasteners
- **Metric/Imperial**: Seamless support for both measurement systems

### Technical Implementation
- **Template-Based System**: Configurable templates for each fastener category
- **Pattern Matching**: Advanced detection using family descriptions and specifications
- **Abbreviation Engine**: Comprehensive mapping system for materials and finishes
- **Dimension Processing**: Intelligent fraction/decimal conversion and metric handling

### Documentation
- Complete README update with templates, examples, and abbreviation tables
- Usage examples for BOM integration and scripting
- Material reference tables with applications

### Test Results
Verified with real McMaster-Carr parts:
- `6294K513` → `FSB-MDSNYL-0.25-0.375-0.25` (MDS-filled nylon flanged bearing)
- `98164A133` → `BHS-SS316-8x32-0.25-HEX` (316 SS button head screw)
- `90480A005` → `HN-S-4x40-ZP` (steel hex nut, zinc-plated)

## Test plan
- [x] Test name generation for all supported fastener categories
- [x] Verify material and finish abbreviation accuracy  
- [x] Validate dimension conversion (fractions to decimals)
- [x] Test steel grade detection across different parts
- [x] Confirm bearing filler material handling
- [x] Validate thread format standardization
- [x] Test metric and imperial part support

🤖 Generated with [Claude Code](https://claude.ai/code)